### PR TITLE
Fix HealthCheckInterface documentation

### DIFF
--- a/docs/USER/developers/api-reference.md
+++ b/docs/USER/developers/api-reference.md
@@ -49,20 +49,6 @@ interface HealthCheckInterface
      * Should be fast (< 1 second target)
      */
     public function run(): HealthCheckResult;
-
-    /**
-     * Get documentation URL for this check (optional)
-     * When set, displays (?) icon that opens URL in new tab
-     * @since 3.0.36
-     */
-    public function getDocsUrl(): ?string;
-
-    /**
-     * Get action URL for this check (optional)
-     * When set, makes result row clickable (navigates same window)
-     * @since 3.0.36
-     */
-    public function getActionUrl(): ?string;
 }
 ```
 


### PR DESCRIPTION
## Summary
- Remove `getDocsUrl()` and `getActionUrl()` from the `HealthCheckInterface` documentation

These methods are **not** part of the interface contract - they are optional methods provided by `AbstractHealthCheck` that developers can override. The documentation incorrectly showed them as interface requirements.

The methods are correctly documented in the `AbstractHealthCheck` section further down in the same file.

## Test plan
- [x] Review the API reference page renders correctly