### PR TITLE
Refactor action_url logic with conditional display and visual buttons

### DIFF
--- a/docs/USER/developers/api-reference.md
+++ b/docs/USER/developers/api-reference.md
@@ -79,8 +79,8 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
     public function run(): HealthCheckResult;
 
     // Optional URL methods (return null by default)
-    public function getDocsUrl(): ?string;   // Override to add (?) docs link
-    public function getActionUrl(): ?string; // Override to make row clickable
+    public function getDocsUrl(): ?string;                        // Override to add "Docs" button
+    public function getActionUrl(?HealthStatus $status = null): ?string; // Override to add "Explore" button
 }
 ```
 
@@ -97,8 +97,8 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
 - `getTitle()` - Loads from language file
 - `getProvider()` - Returns 'core' by default (override if needed)
 - `run()` - Wraps performCheck() with error handling
-- `getDocsUrl()` - Returns null by default (override to add docs link)
-- `getActionUrl()` - Returns null by default (override to make row clickable)
+- `getDocsUrl()` - Returns null by default (override to add "Docs" button)
+- `getActionUrl($status)` - Returns null by default (override to add "Explore" button, receives check status to allow conditional display)
 
 ### Error Handling
 

--- a/docs/USER/developers/examples.md
+++ b/docs/USER/developers/examples.md
@@ -127,6 +127,7 @@ namespace MyCompany\Plugin\HealthChecker\Minimal\Checks;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 defined('_JEXEC') or die;
 
@@ -148,7 +149,7 @@ final class SimpleCheck extends AbstractHealthCheck
     }
 
     /**
-     * Optional: Link to documentation (displays ? icon)
+     * Optional: Link to documentation (displays "Docs" button)
      */
     public function getDocsUrl(): ?string
     {
@@ -156,10 +157,14 @@ final class SimpleCheck extends AbstractHealthCheck
     }
 
     /**
-     * Optional: Link to settings page (makes row clickable)
+     * Optional: Link to settings page (displays "Explore" button)
+     * Only show when there's an issue to fix
      */
-    public function getActionUrl(): ?string
+    public function getActionUrl(?HealthStatus $status = null): ?string
     {
+        if ($status === HealthStatus::Good) {
+            return null;
+        }
         return '/administrator/index.php?option=com_minimal&view=settings';
     }
 

--- a/docs/USER/reading-results.md
+++ b/docs/USER/reading-results.md
@@ -30,6 +30,13 @@ Each health check result includes:
 - **Provider**: Who provides this check (usually "Core")
 - **Description**: Details about what was found
 
+### Action Buttons
+
+Each check row may display action buttons on the right side:
+
+- **Explore**: Takes you to the relevant admin page where you can fix the issue. Only appears when an action is available for that check.
+- **Docs**: Opens documentation for this check in a new tab. Provides detailed explanations, troubleshooting steps, and best practices.
+
 ## Understanding Status Levels
 
 ### Critical (🔴)

--- a/healthchecker/component/media/css/admin-report.css
+++ b/healthchecker/component/media/css/admin-report.css
@@ -90,8 +90,12 @@
     }
 }
 
-/* Hide the external link icon on toolbar buttons with this class */
-.healthchecker-no-external-icon::before {
+/* Hide the external link icon on buttons with this class */
+.healthchecker-no-external-icon::before,
+.healthchecker-no-external-icon::after,
+.healthchecker-no-external-icon .icon-out-2,
+.healthchecker-no-external-icon .fa-external-link,
+.healthchecker-no-external-icon .fa-external-link-alt {
     display: none !important;
 }
 

--- a/healthchecker/component/media/js/admin-report.js
+++ b/healthchecker/component/media/js/admin-report.js
@@ -265,10 +265,13 @@
                     providerBadge = `<span class="badge bg-secondary hasTooltip" title="${escapeHtml(provider.name + (provider.version ? ' v' + provider.version : ''))}">${escapeHtml(provider.name)}</span>`;
                 }
 
-                // Build docs link if docsUrl exists
-                let docsHtml = '';
+                // Build action buttons (action + docs) for the right side
+                let actionButtonsHtml = '';
+                if (result.actionUrl) {
+                    actionButtonsHtml += `<a href="${escapeHtml(result.actionUrl)}" class="btn btn-sm btn-outline-primary">${translations.explore || 'Explore'}</a>`;
+                }
                 if (result.docsUrl) {
-                    docsHtml = `<a href="${escapeHtml(result.docsUrl)}" target="_blank" rel="noopener" class="btn btn-sm btn-link healthchecker-docs-link" title="${translations.viewDocs || 'View Documentation'}"><span class="fa fa-question-circle"></span></a>`;
+                    actionButtonsHtml += `<a href="${escapeHtml(result.docsUrl)}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary ms-1 healthchecker-no-external-icon">${translations.docs || 'Docs'}</a>`;
                 }
 
                 row.innerHTML = `
@@ -281,19 +284,8 @@
                     <td>${escapeHtml(result.title)}</td>
                     <td>${providerBadge}</td>
                     <td class="healthchecker-description">${result.description}</td>
-                    <td>${docsHtml}</td>
+                    <td class="text-end text-nowrap">${actionButtonsHtml}</td>
                 `;
-
-                // Add click handler for actionUrl
-                if (result.actionUrl) {
-                    row.classList.add('healthchecker-action-row');
-                    row.style.cursor = 'pointer';
-                    row.onclick = () => window.location.href = result.actionUrl;
-                } else {
-                    row.classList.remove('healthchecker-action-row');
-                    row.style.cursor = '';
-                    row.onclick = null;
-                }
 
                 // Update card border based on results
                 updateCategoryCardBorder(result.category);
@@ -473,19 +465,17 @@
                                 providerBadge = `<span class="badge bg-secondary hasTooltip" title="${escapeHtml(provider.name + (provider.version ? ' v' + provider.version : ''))}">${escapeHtml(provider.name)}</span>`;
                             }
 
-                            // Build docs link if docsUrl exists
-                            let docsHtml = '';
+                            // Build action buttons (action + docs) for the right side
+                            let actionButtonsHtml = '';
+                            if (result.actionUrl) {
+                                actionButtonsHtml += `<a href="${escapeHtml(result.actionUrl)}" class="btn btn-sm btn-outline-primary">${translations.explore || 'Explore'}</a>`;
+                            }
                             if (result.docsUrl) {
-                                docsHtml = `<a href="${escapeHtml(result.docsUrl)}" target="_blank" rel="noopener" class="btn btn-sm btn-link healthchecker-docs-link" title="${translations.viewDocs || 'View Documentation'}"><span class="fa fa-question-circle"></span></a>`;
+                                actionButtonsHtml += `<a href="${escapeHtml(result.docsUrl)}" target="_blank" rel="noopener" class="btn btn-sm btn-outline-secondary ms-1 healthchecker-no-external-icon">${translations.docs || 'Docs'}</a>`;
                             }
 
-                            // Build row classes and attributes for actionUrl
-                            let rowClass = result.actionUrl ? 'healthchecker-action-row' : '';
-                            let rowStyle = result.actionUrl ? 'cursor: pointer;' : '';
-                            let rowOnclick = result.actionUrl ? `onclick="window.location.href='${escapeHtml(result.actionUrl)}'"` : '';
-
                             rowsHtml += `
-                                <tr id="${rowId}" class="${rowClass}" style="${rowStyle}" ${rowOnclick}>
+                                <tr id="${rowId}">
                                     <td>
                                         <span class="badge ${statusInfo.badgeClass}">
                                             <span class="fa ${statusInfo.icon}" aria-hidden="true"></span>
@@ -495,7 +485,7 @@
                                     <td>${escapeHtml(result.title)}</td>
                                     <td>${providerBadge}</td>
                                     <td class="healthchecker-description">${result.description}</td>
-                                    <td>${docsHtml}</td>
+                                    <td class="text-end text-nowrap">${actionButtonsHtml}</td>
                                 </tr>
                             `;
                         } else {
@@ -554,7 +544,7 @@
                                             <col style="width: 300px;">
                                             <col style="width: 150px;">
                                             <col>
-                                            <col style="width: 40px;">
+                                            <col style="width: 140px;">
                                         </colgroup>
                                         <tbody>${rowsHtml}</tbody>
                                     </table>

--- a/healthchecker/component/src/Check/AbstractHealthCheck.php
+++ b/healthchecker/component/src/Check/AbstractHealthCheck.php
@@ -206,14 +206,21 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
      * to this URL (in the same window) when clicked. Useful for linking to
      * the relevant configuration page for the check.
      *
+     * The optional $status parameter allows checks to conditionally return
+     * an action URL based on the result status. For example, a check might
+     * only return an action URL when the status is Critical or Warning,
+     * returning null for Good status since no action is needed.
+     *
      * Default implementation returns null (row not clickable).
      * Override this method to make the result row link to an action page.
+     *
+     * @param HealthStatus|null $status The result status (Critical/Warning/Good), or null for backwards compatibility
      *
      * @return string|null The action URL or null if not clickable
      *
      * @since 3.0.36
      */
-    public function getActionUrl(): ?string
+    public function getActionUrl(?HealthStatus $status = null): ?string
     {
         return null;
     }
@@ -301,7 +308,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             category: $this->getCategory(),
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(),
-            actionUrl: $this->getActionUrl(),
+            actionUrl: $this->getActionUrl(HealthStatus::Critical),
         );
     }
 
@@ -328,7 +335,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             category: $this->getCategory(),
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(),
-            actionUrl: $this->getActionUrl(),
+            actionUrl: $this->getActionUrl(HealthStatus::Warning),
         );
     }
 
@@ -354,7 +361,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             category: $this->getCategory(),
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(),
-            actionUrl: $this->getActionUrl(),
+            actionUrl: $this->getActionUrl(HealthStatus::Good),
         );
     }
 }

--- a/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php
+++ b/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php
@@ -17,6 +17,7 @@ use Joomla\Event\SubscriberInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Category\HealthCategory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectCategoriesEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectChecksEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectProvidersEvent;
@@ -245,7 +246,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -343,7 +344,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -453,7 +454,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -559,7 +560,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -665,7 +666,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -772,7 +773,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -897,7 +898,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1022,7 +1023,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1133,7 +1134,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1238,7 +1239,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1354,7 +1355,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1466,7 +1467,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1574,7 +1575,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1682,7 +1683,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }
@@ -1790,7 +1791,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_admintools';
             }

--- a/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php
+++ b/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php
@@ -17,6 +17,7 @@ use Joomla\Event\SubscriberInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Category\HealthCategory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectCategoriesEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectChecksEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectProvidersEvent;
@@ -240,7 +241,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -355,7 +356,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -514,7 +515,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -678,7 +679,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -824,7 +825,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -955,7 +956,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -1102,7 +1103,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -1232,7 +1233,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -1365,7 +1366,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }
@@ -1505,7 +1506,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
 
-            public function getActionUrl(): string
+            public function getActionUrl(?HealthStatus $status = null): string
             {
                 return '/administrator/index.php?option=com_akeebabackup';
             }

--- a/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
+++ b/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
@@ -35,6 +35,7 @@ namespace MySitesGuru\HealthChecker\Plugin\MySitesGuru\Checks;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die();
 
@@ -121,7 +122,7 @@ final class MySitesGuruConnectionCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php';
     }
 
-    public function getActionUrl(): string
+    public function getActionUrl(?HealthStatus $status = null): string
     {
         return 'https://mysites.guru';
     }


### PR DESCRIPTION
## Summary

- Add optional `HealthStatus` parameter to `getActionUrl()` allowing checks to conditionally return action URLs based on result status (e.g., hide action button when check passes)
- Replace row-click behavior with explicit **"Explore"** and **"Docs"** buttons on the right side of each result row
- Buttons provide clear visual indicators for actionable items

## Changes

### Core Changes
- `AbstractHealthCheck::getActionUrl()` now accepts optional `?HealthStatus $status` parameter
- Helper methods (`critical()`, `warning()`, `good()`) pass status to `getActionUrl()`
- Frontend JS renders "Explore" and "Docs" text buttons instead of icons
- Added CSS to hide external link icons on docs buttons

### Plugin Updates
- Updated Akeeba Admin Tools plugin (15 checks)
- Updated Akeeba Backup plugin (10 checks)  
- Updated mySites.guru plugin

### Documentation
- Updated user docs explaining new button layout
- Updated developer docs with new method signature and conditional URL examples
- Updated API reference and code examples

## Test plan

- [x] All 2526 tests pass
- [x] PHPStan passes with no errors
- [x] Manual testing: verify "Explore" and "Docs" buttons appear correctly
- [x] Manual testing: verify conditional action URLs work (button hidden for Good status when implemented)

Closes #17
<img width="2558" height="1312" alt="545725658-c95eb4e3-1abd-469a-8d7a-08ab46f55747" src="https://github.com/user-attachments/assets/15ddbcc7-375d-4514-9f71-4a5a102fd9c2" />

