### PR TITLE
Remove duplicate docblocks from performCheck() methods

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Content/DraftArticlesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/DraftArticlesCheck.php
@@ -79,11 +79,6 @@ final class DraftArticlesCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Warning if >20 drafts exist, good otherwise with count
      */
-    /**
-     * Perform the Draft Articles health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/ConnectionCharsetCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/ConnectionCharsetCheck.php
@@ -82,11 +82,6 @@ final class ConnectionCharsetCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with appropriate status and message
      */
-    /**
-     * Perform the Connection Charset health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/MaxPacketCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/MaxPacketCheck.php
@@ -104,11 +104,6 @@ final class MaxPacketCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with appropriate status and message
      */
-    /**
-     * Perform the Max Packet health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/SlowQueryCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/SlowQueryCheck.php
@@ -87,11 +87,6 @@ final class SlowQueryCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with appropriate status and message
      */
-    /**
-     * Perform the Slow Query health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/TableCharsetCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TableCharsetCheck.php
@@ -85,11 +85,6 @@ final class TableCharsetCheck extends AbstractHealthCheck
      * @return HealthCheckResult Critical if database unavailable, warning if any tables
      *                           use non-utf8mb4 collation, good if all tables use utf8mb4
      */
-    /**
-     * Perform the Table Charset health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/TransactionIsolationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TransactionIsolationCheck.php
@@ -102,11 +102,6 @@ final class TransactionIsolationCheck extends AbstractHealthCheck
      *                           is READ-UNCOMMITTED or SERIALIZABLE, good for READ-COMMITTED
      *                           or REPEATABLE-READ (recommended)
      */
-    /**
-     * Perform the Transaction Isolation health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Database/WaitTimeoutCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/WaitTimeoutCheck.php
@@ -108,11 +108,6 @@ final class WaitTimeoutCheck extends AbstractHealthCheck
      *                           is below 30 seconds or above 8 hours, good if timeout
      *                           is in the recommended range
      */
-    /**
-     * Perform the Wait Timeout health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
@@ -79,11 +79,6 @@ final class DisabledExtensionsCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult WARNING if more than 20 extensions are disabled, GOOD otherwise
      */
-    /**
-     * Perform the Disabled Extensions health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
@@ -81,11 +81,6 @@ final class LanguagePacksCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Always returns GOOD with count of site and admin languages
      */
-    /**
-     * Perform the Language Packs health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Performance/BrowserCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/BrowserCacheCheck.php
@@ -85,11 +85,6 @@ final class BrowserCacheCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result indicating browser caching configuration status
      */
-    /**
-     * Perform the Browser Cache health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $htaccessPath = JPATH_ROOT . '/.htaccess';

--- a/healthchecker/plugins/core/src/Checks/Performance/DatabaseQueryCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/DatabaseQueryCacheCheck.php
@@ -90,11 +90,6 @@ final class DatabaseQueryCacheCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result indicating query cache configuration status
      */
-    /**
-     * Perform the Database Query Cache health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Performance/ImageOptimizationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/ImageOptimizationCheck.php
@@ -89,11 +89,6 @@ final class ImageOptimizationCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result indicating image optimization status
      */
-    /**
-     * Perform the Image Optimization health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $imagesPath = JPATH_ROOT . '/images';

--- a/healthchecker/plugins/core/src/Checks/Performance/SmartSearchIndexCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/SmartSearchIndexCheck.php
@@ -86,11 +86,6 @@ final class SmartSearchIndexCheck extends AbstractHealthCheck
      * @return HealthCheckResult Returns GOOD if disabled or indexed,
      *                           WARNING if enabled but empty index
      */
-    /**
-     * Perform the Smart Search Index health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Performance/SystemCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/SystemCacheCheck.php
@@ -91,11 +91,6 @@ final class SystemCacheCheck extends AbstractHealthCheck
      * @return HealthCheckResult Returns WARNING if caching fully disabled,
      *                           GOOD if enabled with handler information
      */
-    /**
-     * Perform the System Cache health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Check Global Configuration caching setting (0=Off, 1=Conservative, 2=Progressive)

--- a/healthchecker/plugins/core/src/Checks/Security/ConfigurationPhpPermissionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ConfigurationPhpPermissionsCheck.php
@@ -90,11 +90,6 @@ final class ConfigurationPhpPermissionsCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Result indicating file permission security level
      */
-    /**
-     * Perform the Configuration Php Permissions health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $configPath = JPATH_ROOT . '/configuration.php';

--- a/healthchecker/plugins/core/src/Checks/Security/ErrorReportingCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ErrorReportingCheck.php
@@ -78,11 +78,6 @@ final class ErrorReportingCheck extends AbstractHealthCheck
      * @return HealthCheckResult WARNING if error reporting is set to maximum/development,
      *                          GOOD if set to none/simple or other production-safe values
      */
-    /**
-     * Perform the Error Reporting health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Get error reporting level from Global Configuration

--- a/healthchecker/plugins/core/src/Checks/Security/MailerSecurityCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/MailerSecurityCheck.php
@@ -82,11 +82,6 @@ final class MailerSecurityCheck extends AbstractHealthCheck
      *                           - GOOD: Using PHP mail()/sendmail, or SMTP with TLS/SSL encryption
      *                           - WARNING: SMTP configured without encryption (none/empty)
      */
-    /**
-     * Perform the Mailer Security health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Get mailer configuration from global Joomla settings

--- a/healthchecker/plugins/core/src/Checks/Seo/AltTextCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/AltTextCheck.php
@@ -78,11 +78,6 @@ final class AltTextCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The check result with status and description
      */
-    /**
-     * Perform the Alt Text health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Seo/RobotsFileCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/RobotsFileCheck.php
@@ -77,11 +77,6 @@ final class RobotsFileCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The check result with status and description
      */
-    /**
-     * Perform the Robots File health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // robots.txt must be in site root to be found by search engine crawlers.

--- a/healthchecker/plugins/core/src/Checks/Seo/SefUrlsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SefUrlsCheck.php
@@ -86,11 +86,6 @@ final class SefUrlsCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Warning if either setting is disabled, Good if both enabled
      */
-    /**
-     * Perform the Sef Urls health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Get SEF configuration from Joomla global configuration

--- a/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
@@ -77,11 +77,6 @@ final class SitemapCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The check result with status and description
      */
-    /**
-     * Perform the Sitemap health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // sitemap.xml must be in site root as per sitemap protocol specification.

--- a/healthchecker/plugins/core/src/Checks/System/DomExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/DomExtensionCheck.php
@@ -79,11 +79,6 @@ final class DomExtensionCheck extends AbstractHealthCheck
      * @return HealthCheckResult Good status if DOM extension is loaded,
      *                            Critical status if DOM extension is not available
      */
-    /**
-     * Perform the Dom Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // DOM is a hard requirement for Joomla

--- a/healthchecker/plugins/core/src/Checks/System/IntlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/IntlExtensionCheck.php
@@ -84,11 +84,6 @@ final class IntlExtensionCheck extends AbstractHealthCheck
      * @return HealthCheckResult Good status if Intl extension is loaded,
      *                            Warning status if Intl extension is not available
      */
-    /**
-     * Perform the Intl Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Intl provides enhanced internationalization but is not strictly required

--- a/healthchecker/plugins/core/src/Checks/System/JsonExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/JsonExtensionCheck.php
@@ -77,11 +77,6 @@ final class JsonExtensionCheck extends AbstractHealthCheck
      * @return HealthCheckResult Good status if JSON extension is loaded,
      *                            Critical status if JSON extension is not available
      */
-    /**
-     * Perform the Json Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // JSON is a hard requirement for Joomla

--- a/healthchecker/plugins/core/src/Checks/System/MailFunctionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MailFunctionCheck.php
@@ -81,11 +81,6 @@ final class MailFunctionCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Critical/Warning/Good based on mail configuration validity
      */
-    /**
-     * Perform the Mail Function health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Get configured mailer from Joomla config (mail, smtp, or sendmail)

--- a/healthchecker/plugins/core/src/Checks/System/OpenSslExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OpenSslExtensionCheck.php
@@ -86,11 +86,6 @@ final class OpenSslExtensionCheck extends AbstractHealthCheck
      * @return HealthCheckResult Good status if OpenSSL extension is loaded (with version),
      *                            Critical status if OpenSSL extension is not available
      */
-    /**
-     * Perform the Open Ssl Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // OpenSSL is essential for secure operation of any modern Joomla site

--- a/healthchecker/plugins/core/src/Checks/System/OutputBufferingCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OutputBufferingCheck.php
@@ -84,11 +84,6 @@ final class OutputBufferingCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Always returns Good as this is informational only
      */
-    /**
-     * Perform the Output Buffering health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $outputBuffering = ini_get('output_buffering');

--- a/healthchecker/plugins/core/src/Checks/System/PdoMysqlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PdoMysqlExtensionCheck.php
@@ -76,11 +76,6 @@ final class PdoMysqlExtensionCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult CRITICAL if pdo_mysql is not loaded, GOOD if available
      */
-    /**
-     * Perform the Pdo Mysql Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         if (! extension_loaded('pdo_mysql')) {

--- a/healthchecker/plugins/core/src/Checks/System/ServerTimeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ServerTimeCheck.php
@@ -98,11 +98,6 @@ final class ServerTimeCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult Good if time is accurate, Warning/Critical if drifted
      */
-    /**
-     * Perform the Server Time health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $timezone = date_default_timezone_get();

--- a/healthchecker/plugins/core/src/Checks/System/SimpleXmlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/SimpleXmlExtensionCheck.php
@@ -78,11 +78,6 @@ final class SimpleXmlExtensionCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult CRITICAL if simplexml is not loaded, GOOD if available
      */
-    /**
-     * Perform the Simple Xml Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         if (! extension_loaded('simplexml')) {

--- a/healthchecker/plugins/core/src/Checks/System/ZipExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ZipExtensionCheck.php
@@ -80,11 +80,6 @@ final class ZipExtensionCheck extends AbstractHealthCheck
      * @return HealthCheckResult Good status if Zip extension is loaded,
      *                            Critical status if Zip extension is not available
      */
-    /**
-     * Perform the Zip Extension health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Zip is essential for extension management and updates

--- a/healthchecker/plugins/core/src/Checks/Users/AdminEmailCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/AdminEmailCheck.php
@@ -105,11 +105,6 @@ final class AdminEmailCheck extends AbstractHealthCheck
      * @return HealthCheckResult CRITICAL if invalid emails found, GOOD if all valid,
      *                          WARNING if no super admins exist
      */
-    /**
-     * Perform the Admin Email health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Users/DefaultUserGroupCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/DefaultUserGroupCheck.php
@@ -92,11 +92,6 @@ final class DefaultUserGroupCheck extends AbstractHealthCheck
      * @return HealthCheckResult CRITICAL if default group is Administrator/Super Users,
      *                          GOOD if set to appropriate non-privileged group
      */
-    /**
-     * Perform the Default User Group health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Read com_users configuration to get default user group for new registrations

--- a/healthchecker/plugins/core/src/Checks/Users/LastLoginCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/LastLoginCheck.php
@@ -86,11 +86,6 @@ final class LastLoginCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with status (GOOD/WARNING) and message
      */
-    /**
-     * Perform the Last Login health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Users/UserFieldsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserFieldsCheck.php
@@ -88,11 +88,6 @@ final class UserFieldsCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with GOOD status and field count information
      */
-    /**
-     * Perform the User Fields health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Users/UserGroupsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserGroupsCheck.php
@@ -85,11 +85,6 @@ final class UserGroupsCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with status (GOOD/WARNING) and group count
      */
-    /**
-     * Perform the User Groups health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Users/UserNotesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserNotesCheck.php
@@ -86,11 +86,6 @@ final class UserNotesCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with GOOD status and note/user counts
      */
-    /**
-     * Perform the User Notes health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         $database = $this->requireDatabase();

--- a/healthchecker/plugins/core/src/Checks/Users/UserRegistrationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserRegistrationCheck.php
@@ -90,11 +90,6 @@ final class UserRegistrationCheck extends AbstractHealthCheck
      *
      * @return HealthCheckResult The result with status (GOOD/WARNING) and configuration state
      */
-    /**
-     * Perform the User Registration health check.
-     *
-     * @return HealthCheckResult The result of this health check
-     */
     protected function performCheck(): HealthCheckResult
     {
         // Read the component parameters for com_users to check registration setting


### PR DESCRIPTION
## Summary
- Remove redundant generic docblocks stacked before `performCheck()` methods
- 38 health check files had two docblocks: a detailed one and a generic one. The generic one is removed.

## Test plan
- [ ] `composer check` passes