### PR TITLE
Standardize die() to die; for consistency

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
@@ -39,7 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 
-\defined('_JEXEC') || die();
+\defined('_JEXEC') || die;
 
 final class UnusedModulesCheck extends AbstractHealthCheck
 {

--- a/healthchecker/plugins/example/src/Checks/ThirdPartyServiceCheck.php
+++ b/healthchecker/plugins/example/src/Checks/ThirdPartyServiceCheck.php
@@ -53,7 +53,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Example\Checks;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 
-\defined('_JEXEC') || die();
+\defined('_JEXEC') || die;
 
 /**
  * Example health check demonstrating external service monitoring.

--- a/healthchecker/plugins/example/src/Extension/ExamplePlugin.php
+++ b/healthchecker/plugins/example/src/Extension/ExamplePlugin.php
@@ -22,7 +22,7 @@ use MySitesGuru\HealthChecker\Component\Administrator\Provider\ProviderMetadata;
 use MySitesGuru\HealthChecker\Plugin\Example\Checks\CustomConfigCheck;
 use MySitesGuru\HealthChecker\Plugin\Example\Checks\ThirdPartyServiceCheck;
 
-\defined('_JEXEC') || die();
+\defined('_JEXEC') || die;
 
 /**
  * Example Health Checker Plugin

--- a/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
+++ b/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
@@ -37,7 +37,7 @@ use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
-\defined('_JEXEC') || die();
+\defined('_JEXEC') || die;
 
 /**
  * mySites.guru Connection Health Check


### PR DESCRIPTION
## Summary
- Change `die()` to `die;` in 4 files to match the convention used in the other 171 files

## Test plan
- [ ] `composer check` passes