### PR TITLE
Add HealthStatus parameter to getDocsUrl() method

### DIFF
--- a/docs/USER/developers/api-reference.md
+++ b/docs/USER/developers/api-reference.md
@@ -79,8 +79,8 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
     public function run(): HealthCheckResult;
 
     // Optional URL methods (return null by default)
-    public function getDocsUrl(): ?string;                        // Override to add "Docs" button
-    public function getActionUrl(?HealthStatus $status = null): ?string; // Override to add "Explore" button
+    public function getDocsUrl(?HealthStatus $healthStatus = null): ?string;   // Override to add "Docs" button
+    public function getActionUrl(?HealthStatus $status = null): ?string;       // Override to add "Explore" button
 }
 ```
 
@@ -97,7 +97,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
 - `getTitle()` - Loads from language file
 - `getProvider()` - Returns 'core' by default (override if needed)
 - `run()` - Wraps performCheck() with error handling
-- `getDocsUrl()` - Returns null by default (override to add "Docs" button)
+- `getDocsUrl($healthStatus)` - Returns null by default (override to add "Docs" button, receives check status to allow conditional display)
 - `getActionUrl($status)` - Returns null by default (override to add "Explore" button, receives check status to allow conditional display)
 
 ### Error Handling

--- a/docs/USER/developers/creating-checks.md
+++ b/docs/USER/developers/creating-checks.md
@@ -67,8 +67,26 @@ Health checks can provide two optional URLs that display as buttons on the right
 When implemented, displays a **"Docs"** button on the right side of the result row. Clicking the button opens the documentation URL in a new browser tab.
 
 ```php
-public function getDocsUrl(): ?string
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
+
+public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
 {
+    return 'https://docs.yoursite.com/checks/example-check';
+}
+```
+
+The method receives an optional `HealthStatus` parameter, allowing you to conditionally show the docs button based on the check result.
+
+**Conditional Docs URLs**:
+
+```php
+public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
+{
+    // Only show docs button when there's something to investigate (not for Good status)
+    if ($healthStatus === HealthStatus::Good) {
+        return null;
+    }
+
     return 'https://docs.yoursite.com/checks/example-check';
 }
 ```
@@ -77,6 +95,7 @@ public function getDocsUrl(): ?string
 - Link to detailed documentation explaining the check
 - Link to troubleshooting guides
 - Link to the source code on GitHub
+- Hide the docs button when no further guidance is needed (Good status)
 
 ### Action URL (`getActionUrl`)
 
@@ -137,7 +156,7 @@ final class ApiConfigCheck extends AbstractHealthCheck
         return 'yourplugin';
     }
 
-    public function getDocsUrl(): ?string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
     {
         return 'https://docs.yoursite.com/configuration/api-settings';
     }
@@ -165,7 +184,7 @@ final class ApiConfigCheck extends AbstractHealthCheck
 - `getDocsUrl()` opens in a new tab, `getActionUrl()` opens in the same window
 - Action URLs should be relative administrator paths (starting with `/administrator/`)
 - Documentation URLs can be absolute URLs to external documentation
-- The `$status` parameter is optional for backwards compatibility - existing checks without it will continue to work
+- Both `$healthStatus` and `$status` parameters are optional for backwards compatibility - existing checks without them will continue to work
 
 ## Check Slug Format
 
@@ -603,7 +622,7 @@ final class ApiConnectionCheck extends AbstractHealthCheck
      *
      * Displays a "Docs" button that opens this URL in a new tab.
      */
-    public function getDocsUrl(): ?string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
     {
         return 'https://docs.yoursite.com/health-checks/api-connection';
     }

--- a/docs/USER/developers/examples.md
+++ b/docs/USER/developers/examples.md
@@ -150,9 +150,14 @@ final class SimpleCheck extends AbstractHealthCheck
 
     /**
      * Optional: Link to documentation (displays "Docs" button)
+     * Only show when there's an issue to investigate
      */
-    public function getDocsUrl(): ?string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
     {
+        if ($healthStatus === HealthStatus::Good) {
+            return null;
+        }
+
         return 'https://example.com/docs/simple-check';
     }
 

--- a/healthchecker/component/src/Check/AbstractHealthCheck.php
+++ b/healthchecker/component/src/Check/AbstractHealthCheck.php
@@ -184,17 +184,24 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
     /**
      * Get the documentation URL for this check.
      *
-     * When implemented, this URL is displayed as a (?) icon next to the check
+     * When implemented, this URL is displayed as a "Docs" button next to the check
      * that opens the documentation in a new tab when clicked.
+     *
+     * The optional $healthStatus parameter allows checks to conditionally return
+     * a documentation URL based on the result status. For example, a check might
+     * only return a docs URL when the status is Critical or Warning,
+     * returning null for Good status since documentation is not needed.
      *
      * Default implementation returns null (no documentation link).
      * Override this method to provide a link to documentation for your check.
+     *
+     * @param HealthStatus|null $healthStatus The result status (Critical/Warning/Good), or null for backwards compatibility
      *
      * @return string|null The documentation URL or null if none
      *
      * @since 3.0.36
      */
-    public function getDocsUrl(): ?string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
     {
         return null;
     }
@@ -307,7 +314,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             slug: $this->getSlug(),
             category: $this->getCategory(),
             provider: $this->getProvider(),
-            docsUrl: $this->getDocsUrl(),
+            docsUrl: $this->getDocsUrl(HealthStatus::Critical),
             actionUrl: $this->getActionUrl(HealthStatus::Critical),
         );
     }
@@ -334,7 +341,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             slug: $this->getSlug(),
             category: $this->getCategory(),
             provider: $this->getProvider(),
-            docsUrl: $this->getDocsUrl(),
+            docsUrl: $this->getDocsUrl(HealthStatus::Warning),
             actionUrl: $this->getActionUrl(HealthStatus::Warning),
         );
     }
@@ -360,7 +367,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             slug: $this->getSlug(),
             category: $this->getCategory(),
             provider: $this->getProvider(),
-            docsUrl: $this->getDocsUrl(),
+            docsUrl: $this->getDocsUrl(HealthStatus::Good),
             actionUrl: $this->getActionUrl(HealthStatus::Good),
         );
     }

--- a/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php
+++ b/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php
@@ -241,7 +241,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_INSTALLED_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -339,7 +339,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_WAF_ENABLED_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -449,7 +449,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_SECURITY_EVENTS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -555,7 +555,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_BLOCKED_ATTACKS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -661,7 +661,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_ACTIVE_BANS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -768,7 +768,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_SCAN_AGE_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -893,7 +893,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_FILE_ALERTS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1018,7 +1018,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_TEMP_SUPERUSERS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1129,7 +1129,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_IP_WHITELIST_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1234,7 +1234,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_WAF_RULES_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1350,7 +1350,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_LOGIN_FAILURES_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1462,7 +1462,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_GEOBLOCKING_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1570,7 +1570,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_SQLI_BLOCKS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1678,7 +1678,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_XSS_BLOCKS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }
@@ -1786,7 +1786,7 @@ final class AkeebaAdminToolsPlugin extends CMSPlugin implements SubscriberInterf
                 return Text::_('PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_ADMIN_ACCESS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebaadmintools/src/Extension/AkeebaAdminToolsPlugin.php';
             }

--- a/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php
+++ b/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php
@@ -236,7 +236,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_INSTALLED_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -351,7 +351,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_LAST_BACKUP_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -510,7 +510,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_SUCCESS_RATE_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -674,7 +674,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_STUCK_BACKUPS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -820,7 +820,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_FILES_EXIST_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -951,7 +951,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_BACKUP_SIZE_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -1098,7 +1098,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_PROFILE_EXISTS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -1228,7 +1228,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_PROFILE_CONFIGURED_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -1361,7 +1361,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_FAILED_BACKUPS_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }
@@ -1501,7 +1501,7 @@ final class AkeebaBackupPlugin extends CMSPlugin implements SubscriberInterface
                 return Text::_('PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_FREQUENCY_TITLE');
             }
 
-            public function getDocsUrl(): string
+            public function getDocsUrl(?HealthStatus $healthStatus = null): string
             {
                 return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/akeebabackup/src/Extension/AkeebaBackupPlugin.php';
             }

--- a/healthchecker/plugins/core/src/Checks/Content/ArchivedContentCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/ArchivedContentCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ArchivedContentCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/ArchivedContentCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/CategoryDepthCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/CategoryDepthCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class CategoryDepthCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/CategoryDepthCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/DraftArticlesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/DraftArticlesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class DraftArticlesCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/DraftArticlesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/EmptyArticlesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/EmptyArticlesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class EmptyArticlesCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/EmptyArticlesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/ExpiredContentCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/ExpiredContentCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class ExpiredContentCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/ExpiredContentCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/MenuOrphansCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/MenuOrphansCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class MenuOrphansCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/MenuOrphansCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/OrphanedArticlesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/OrphanedArticlesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class OrphanedArticlesCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/OrphanedArticlesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/ScheduledContentCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/ScheduledContentCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ScheduledContentCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/ScheduledContentCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/TrashedContentCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/TrashedContentCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class TrashedContentCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/TrashedContentCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/UncategorizedContentCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/UncategorizedContentCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class UncategorizedContentCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/UncategorizedContentCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Content/UnpublishedCategoryArticlesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Content/UnpublishedCategoryArticlesCheck.php
@@ -46,6 +46,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Content;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -71,7 +72,7 @@ final class UnpublishedCategoryArticlesCheck extends AbstractHealthCheck
         return 'content';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Content/UnpublishedCategoryArticlesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/AutoIncrementCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/AutoIncrementCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -69,7 +70,7 @@ final class AutoIncrementCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/AutoIncrementCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/ConnectionCharsetCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/ConnectionCharsetCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class ConnectionCharsetCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/ConnectionCharsetCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/ConnectionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/ConnectionCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class ConnectionCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/ConnectionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/IndexUsageCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/IndexUsageCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -82,7 +83,7 @@ final class IndexUsageCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/IndexUsageCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/MaxPacketCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/MaxPacketCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -82,7 +83,7 @@ final class MaxPacketCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/MaxPacketCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/OrphanedTablesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/OrphanedTablesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class OrphanedTablesCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/OrphanedTablesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/ServerVersionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/ServerVersionCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -77,7 +78,7 @@ final class ServerVersionCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/ServerVersionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/SizeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/SizeCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -85,7 +86,7 @@ final class SizeCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/SizeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/SlowQueryCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/SlowQueryCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class SlowQueryCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/SlowQueryCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/SqlModeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/SqlModeCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -69,7 +70,7 @@ final class SqlModeCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/SqlModeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/TableCharsetCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TableCharsetCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class TableCharsetCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/TableCharsetCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/TableEngineCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TableEngineCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class TableEngineCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/TableEngineCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/TablePrefixCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TablePrefixCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class TablePrefixCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/TablePrefixCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/TableStatusCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TableStatusCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class TableStatusCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/TableStatusCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/TransactionIsolationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/TransactionIsolationCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -75,7 +76,7 @@ final class TransactionIsolationCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/TransactionIsolationCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/UserPrivilegesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/UserPrivilegesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -76,7 +77,7 @@ final class UserPrivilegesCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/UserPrivilegesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Database/WaitTimeoutCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/WaitTimeoutCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Database;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -85,7 +86,7 @@ final class WaitTimeoutCheck extends AbstractHealthCheck
         return 'database';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Database/WaitTimeoutCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php
@@ -39,6 +39,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class CachePluginCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
@@ -34,6 +34,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -59,7 +60,7 @@ final class DisabledExtensionsCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/JoomlaCoreVersionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/JoomlaCoreVersionCheck.php
@@ -34,6 +34,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 use Joomla\CMS\Version;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -59,7 +60,7 @@ final class JoomlaCoreVersionCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/JoomlaCoreVersionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
@@ -33,6 +33,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -58,7 +59,7 @@ final class LanguagePacksCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php
@@ -35,6 +35,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -60,7 +61,7 @@ final class MissingUpdatesCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class ModulePositionCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class OverrideCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class PluginOrderCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class SearchPluginsCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class TemplateCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class UnusedModulesCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php
@@ -35,6 +35,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -60,7 +61,7 @@ final class UpdateSitesCheck extends AbstractHealthCheck
         return 'extensions';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/BrowserCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/BrowserCacheCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class BrowserCacheCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/BrowserCacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/DatabaseQueryCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/DatabaseQueryCacheCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class DatabaseQueryCacheCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/DatabaseQueryCacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/GzipCompressionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/GzipCompressionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class GzipCompressionCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/GzipCompressionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/ImageOptimizationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/ImageOptimizationCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -71,7 +72,7 @@ final class ImageOptimizationCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/ImageOptimizationCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/LazyLoadCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/LazyLoadCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 use Joomla\CMS\Plugin\PluginHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class LazyLoadCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/LazyLoadCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/MediaManagerThumbnailsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/MediaManagerThumbnailsCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class MediaManagerThumbnailsCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/MediaManagerThumbnailsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/PageCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/PageCacheCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 use Joomla\CMS\Plugin\PluginHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class PageCacheCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/PageCacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/RedirectsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/RedirectsCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class RedirectsCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/RedirectsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/SmartSearchIndexCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/SmartSearchIndexCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Performance;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class SmartSearchIndexCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/SmartSearchIndexCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Performance/SystemCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/SystemCacheCheck.php
@@ -38,6 +38,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class SystemCacheCheck extends AbstractHealthCheck
         return 'performance';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Performance/SystemCacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ActionLogsEnabledCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ActionLogsEnabledCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ActionLogsEnabledCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ActionLogsEnabledCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/AdminUsernameCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/AdminUsernameCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class AdminUsernameCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/AdminUsernameCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ApiAuthCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ApiAuthCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ApiAuthCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ApiAuthCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ConfigurationPhpPermissionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ConfigurationPhpPermissionsCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class ConfigurationPhpPermissionsCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ConfigurationPhpPermissionsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ContentSecurityPolicyCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ContentSecurityPolicyCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class ContentSecurityPolicyCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ContentSecurityPolicyCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/CorsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/CorsCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class CorsCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/CorsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/DebugModeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/DebugModeCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class DebugModeCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/DebugModeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/DefaultSecretCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/DefaultSecretCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -73,7 +74,7 @@ final class DefaultSecretCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/DefaultSecretCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ErrorReportingCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ErrorReportingCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class ErrorReportingCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ErrorReportingCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ForceSslCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ForceSslCheck.php
@@ -40,6 +40,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class ForceSslCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ForceSslCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/HtaccessProtectionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/HtaccessProtectionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class HtaccessProtectionCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/HtaccessProtectionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/HttpsRedirectCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/HttpsRedirectCheck.php
@@ -41,6 +41,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class HttpsRedirectCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/HttpsRedirectCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/IndexFileCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/IndexFileCheck.php
@@ -34,6 +34,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -68,7 +69,7 @@ final class IndexFileCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/IndexFileCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/MailerSecurityCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/MailerSecurityCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class MailerSecurityCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/MailerSecurityCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/PasswordPolicyCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/PasswordPolicyCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Component\ComponentHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class PasswordPolicyCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/PasswordPolicyCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/PrivacyDashboardCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/PrivacyDashboardCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class PrivacyDashboardCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/PrivacyDashboardCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/ReCaptchaCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/ReCaptchaCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ReCaptchaCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/ReCaptchaCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/SessionHandlerCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/SessionHandlerCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class SessionHandlerCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/SessionHandlerCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/SessionLifetimeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/SessionLifetimeCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -78,7 +79,7 @@ final class SessionLifetimeCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/SessionLifetimeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/TwoFactorAuthCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/TwoFactorAuthCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class TwoFactorAuthCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/TwoFactorAuthCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Security/XFrameOptionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Security/XFrameOptionsCheck.php
@@ -44,6 +44,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Security;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -69,7 +70,7 @@ final class XFrameOptionsCheck extends AbstractHealthCheck
         return 'security';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Security/XFrameOptionsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/AltTextCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/AltTextCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class AltTextCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/AltTextCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/BrokenLinksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/BrokenLinksCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class BrokenLinksCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/BrokenLinksCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/CanonicalUrlCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/CanonicalUrlCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class CanonicalUrlCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/CanonicalUrlCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/FacebookOpenGraphCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/FacebookOpenGraphCheck.php
@@ -48,6 +48,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -85,7 +86,7 @@ final class FacebookOpenGraphCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/FacebookOpenGraphCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/MetaKeywordsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/MetaKeywordsCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class MetaKeywordsCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/MetaKeywordsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/OpenGraphCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/OpenGraphCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class OpenGraphCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/OpenGraphCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/RobotsFileCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/RobotsFileCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class RobotsFileCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/RobotsFileCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/SefUrlsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SefUrlsCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class SefUrlsCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/SefUrlsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/SiteMetaDescriptionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SiteMetaDescriptionCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class SiteMetaDescriptionCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/SiteMetaDescriptionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class SitemapCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/StructuredDataCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/StructuredDataCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class StructuredDataCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/StructuredDataCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
@@ -47,6 +47,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -95,7 +96,7 @@ final class TwitterCardsCheck extends AbstractHealthCheck
         return 'seo';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/ApacheModulesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ApacheModulesCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class ApacheModulesCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/ApacheModulesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/CoreDirectoriesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/CoreDirectoriesCheck.php
@@ -35,6 +35,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -82,7 +83,7 @@ final class CoreDirectoriesCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/CoreDirectoriesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/CurlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/CurlExtensionCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class CurlExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/CurlExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/DiskSpaceCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/DiskSpaceCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -78,7 +79,7 @@ final class DiskSpaceCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/DiskSpaceCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/DomExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/DomExtensionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class DomExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/DomExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/ExifExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ExifExtensionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class ExifExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/ExifExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/FailedTasksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/FailedTasksCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class FailedTasksCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/FailedTasksCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/FileinfoExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/FileinfoExtensionCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class FileinfoExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/FileinfoExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/GdOrImagickCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/GdOrImagickCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class GdOrImagickCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/GdOrImagickCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/IntlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/IntlExtensionCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class IntlExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/IntlExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/JsonExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/JsonExtensionCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class JsonExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/JsonExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/LogFileSizeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/LogFileSizeCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -78,7 +79,7 @@ final class LogFileSizeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/LogFileSizeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MailFunctionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MailFunctionCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class MailFunctionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MailFunctionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MaxExecutionTimeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MaxExecutionTimeCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -74,7 +75,7 @@ final class MaxExecutionTimeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MaxExecutionTimeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MaxInputTimeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MaxInputTimeCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class MaxInputTimeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MaxInputTimeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MaxInputVarsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MaxInputVarsCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -75,7 +76,7 @@ final class MaxInputVarsCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MaxInputVarsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MbstringExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MbstringExtensionCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class MbstringExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MbstringExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/MemoryLimitCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/MemoryLimitCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -75,7 +76,7 @@ final class MemoryLimitCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/MemoryLimitCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/OpcacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OpcacheCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class OpcacheCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/OpcacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/OpenSslExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OpenSslExtensionCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -68,7 +69,7 @@ final class OpenSslExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/OpenSslExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/OutputBufferingCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OutputBufferingCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class OutputBufferingCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/OutputBufferingCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/OverdueTasksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/OverdueTasksCheck.php
@@ -39,6 +39,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -64,7 +65,7 @@ final class OverdueTasksCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/OverdueTasksCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/PdoMysqlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PdoMysqlExtensionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class PdoMysqlExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/PdoMysqlExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/PhpEolCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PhpEolCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -83,7 +84,7 @@ final class PhpEolCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/PhpEolCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/PhpSapiCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PhpSapiCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -71,7 +72,7 @@ final class PhpSapiCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/PhpSapiCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/PhpVersionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PhpVersionCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -73,7 +74,7 @@ final class PhpVersionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/PhpVersionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/PostMaxSizeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/PostMaxSizeCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -75,7 +76,7 @@ final class PostMaxSizeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/PostMaxSizeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/RealpathCacheCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/RealpathCacheCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -70,7 +71,7 @@ final class RealpathCacheCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/RealpathCacheCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/ServerTimeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ServerTimeCheck.php
@@ -44,6 +44,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -84,7 +85,7 @@ final class ServerTimeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/ServerTimeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/SessionSavePathCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/SessionSavePathCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class SessionSavePathCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/SessionSavePathCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/SimpleXmlExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/SimpleXmlExtensionCheck.php
@@ -37,6 +37,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -62,7 +63,7 @@ final class SimpleXmlExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/SimpleXmlExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/TempDirectoryCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/TempDirectoryCheck.php
@@ -36,6 +36,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 use Joomla\CMS\Factory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -61,7 +62,7 @@ final class TempDirectoryCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/TempDirectoryCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/UploadMaxFilesizeCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/UploadMaxFilesizeCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -77,7 +78,7 @@ final class UploadMaxFilesizeCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/UploadMaxFilesizeCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/System/ZipExtensionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/System/ZipExtensionCheck.php
@@ -38,6 +38,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\System;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -63,7 +64,7 @@ final class ZipExtensionCheck extends AbstractHealthCheck
         return 'system';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/System/ZipExtensionCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/AdminEmailCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/AdminEmailCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -89,7 +90,7 @@ final class AdminEmailCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/AdminEmailCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/BlockedUsersCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/BlockedUsersCheck.php
@@ -41,6 +41,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -66,7 +67,7 @@ final class BlockedUsersCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/BlockedUsersCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/DefaultUserGroupCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/DefaultUserGroupCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 use Joomla\CMS\Component\ComponentHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -76,7 +77,7 @@ final class DefaultUserGroupCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/DefaultUserGroupCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/DuplicateEmailsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/DuplicateEmailsCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class DuplicateEmailsCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/DuplicateEmailsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/InactiveUsersCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/InactiveUsersCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -75,7 +76,7 @@ final class InactiveUsersCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/InactiveUsersCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/LastLoginCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/LastLoginCheck.php
@@ -44,6 +44,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -69,7 +70,7 @@ final class LastLoginCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/LastLoginCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/PasswordExpiryCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/PasswordExpiryCheck.php
@@ -45,6 +45,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -77,7 +78,7 @@ final class PasswordExpiryCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/PasswordExpiryCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/SuperAdminCountCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/SuperAdminCountCheck.php
@@ -40,6 +40,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -65,7 +66,7 @@ final class SuperAdminCountCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/SuperAdminCountCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/UserFieldsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserFieldsCheck.php
@@ -46,6 +46,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -71,7 +72,7 @@ final class UserFieldsCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/UserFieldsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/UserGroupsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserGroupsCheck.php
@@ -43,6 +43,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -68,7 +69,7 @@ final class UserGroupsCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/UserGroupsCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/UserNotesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserNotesCheck.php
@@ -42,6 +42,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -67,7 +68,7 @@ final class UserNotesCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/UserNotesCheck.php';
     }

--- a/healthchecker/plugins/core/src/Checks/Users/UserRegistrationCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Users/UserRegistrationCheck.php
@@ -44,6 +44,7 @@ namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Users;
 use Joomla\CMS\Component\ComponentHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 \defined('_JEXEC') || die;
 
@@ -69,7 +70,7 @@ final class UserRegistrationCheck extends AbstractHealthCheck
         return 'users';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Users/UserRegistrationCheck.php';
     }

--- a/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
+++ b/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php
@@ -117,7 +117,7 @@ final class MySitesGuruConnectionCheck extends AbstractHealthCheck
         return 'mysitesguru';
     }
 
-    public function getDocsUrl(): string
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
     {
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/mysitesguru/src/Checks/MySitesGuruConnectionCheck.php';
     }


### PR DESCRIPTION
## Summary

- Adds optional `?HealthStatus $healthStatus = null` parameter to `getDocsUrl()`, matching the existing `getActionUrl()` pattern
- Passes the health status through the `critical()`, `warning()`, and `good()` helper methods
- Updates all 129+ check class overrides with the new signature
- Adds test coverage for conditional docs URLs based on status
- Updates developer documentation with examples

Closes #38

## Breaking Change

**This is a breaking change for third-party plugins** that override `getDocsUrl()`. Any plugin that overrides this method must update its signature from:

```php
public function getDocsUrl(): ?string
```

to:

```php
public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
```

Without this change, PHP will emit a deprecation notice (PHP 8.x) or fatal error (PHP 9.0+) about incompatible method signatures.

## Usage

Check authors can now conditionally hide the docs button based on result status:

```php
public function getDocsUrl(?HealthStatus $healthStatus = null): ?string
{
    // No docs link needed when everything is fine
    if ($healthStatus === HealthStatus::Good) {
        return null;
    }

    return 'https://example.com/docs/my-check';
}
```

## Test plan

- [x] All 2567 existing tests pass
- [x] New `testConditionalDocsUrlBasedOnStatus` test verifies conditional behavior
- [x] `composer check` passes (ECS, Rector, PHPStan Level 8, PHPUnit)