### PR TITLE
List orphaned modules in Module Position check warning

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
@@ -150,11 +150,17 @@ final class ModulePositionCheck extends AbstractHealthCheck
         $orphanedCount = \count($orphanedModules);
 
         if ($orphanedCount > 0) {
+            $list = '<ul><li>' . implode(
+                '</li><li>',
+                array_map(htmlspecialchars(...), $orphanedModules),
+            ) . '</li></ul>';
+
             return $this->warning(
                 sprintf(
-                    '%d published module(s) assigned to positions not defined in template %s.',
+                    '%d published module(s) assigned to positions not defined in template %s:%s',
                     $orphanedCount,
-                    $activeTemplate->template,
+                    htmlspecialchars($activeTemplate->template),
+                    $list,
                 ),
             );
         }

--- a/tests/Unit/Plugin/Core/Checks/Extensions/ModulePositionCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Extensions/ModulePositionCheckTest.php
@@ -238,6 +238,9 @@ XML;
         $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
         $this->assertStringContainsString('2 published module(s)', $healthCheckResult->description);
         $this->assertStringContainsString('not defined in template', $healthCheckResult->description);
+        $this->assertStringContainsString('<ul>', $healthCheckResult->description);
+        $this->assertStringContainsString('<li>Sidebar Module (sidebar-left)</li>', $healthCheckResult->description);
+        $this->assertStringContainsString('<li>Banner Module (banner)</li>', $healthCheckResult->description);
     }
 
     public function testRunWithNoPublishedModulesReturnsGood(): void


### PR DESCRIPTION
## Summary

- The Module Position check warning now lists each orphaned module and its invalid position name in a `<ul>`
- Admins can see exactly which modules need reassignment without digging further

Closes #40

## Test plan

- [x] Existing tests updated to verify the HTML list is present in the warning description
- [x] All 2567 tests pass
- [x] `composer check` passes (ECS, Rector, PHPStan Level 8, PHPUnit)