### PR TITLE
Mention {loadmodule} in Unused Modules check wording

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
@@ -163,7 +163,10 @@ final class UnusedModulesCheck extends AbstractHealthCheck
 
         if ($totalUnused > 0) {
             return $this->warning(
-                sprintf('%d published module(s) have no menu assignment — this is fine if they are loaded via {loadmodule} in articles.', $totalUnused),
+                sprintf(
+                    '%d published module(s) have no menu assignment — this is fine if they are loaded via {loadmodule} in articles.',
+                    $totalUnused,
+                ),
             );
         }
 


### PR DESCRIPTION
## Summary

- Updated warning messages to note that modules without menu assignments may be loaded via `{loadmodule}` in articles
- Updated docblock to reflect the same nuance
- No logic changes — just wording

Fixes #47

## Test plan

- [x] Existing tests pass (wording change doesn't break assertions)
- [x] ECS / PHPStan clean

//cc @cybersalt