### PR TITLE
Add BeforeReportExportDisplayEvent for plugin banners in HTML exports

### DIFF
--- a/healthchecker/component/src/Event/BeforeReportExportDisplayEvent.php
+++ b/healthchecker/component/src/Event/BeforeReportExportDisplayEvent.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright   (C) 2026 https://mySites.guru + Phil E. Taylor <phil@phil-taylor.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @link        https://github.com/mySites-guru/HealthCheckerForJoomla
+ */
+
+namespace MySitesGuru\HealthChecker\Component\Administrator\Event;
+
+use Joomla\Event\Event;
+
+\defined('_JEXEC') || die;
+
+/**
+ * Event triggered before the health check HTML export report is displayed
+ *
+ * This event allows plugins to inject content (like promotional banners) into the
+ * HTML export report before it's rendered. Plugins can add HTML content that will
+ * be displayed between the summary cards and the check results in the exported file.
+ *
+ * Unlike BeforeReportDisplayEvent (which targets the admin UI), this event targets
+ * the standalone HTML export that users can download and share. Banners injected here
+ * should be self-contained since the export has no external CSS or JavaScript dependencies.
+ *
+ * @since 3.4.0
+ */
+final class BeforeReportExportDisplayEvent extends Event
+{
+    /**
+     * HTML content to inject before the report export results
+     *
+     * @var string[]
+     * @since 3.4.0
+     */
+    private array $htmlContent = [];
+
+    /**
+     * Constructs the BeforeReportExportDisplayEvent.
+     *
+     * Initializes the event with the name from the HealthCheckerEvents enum
+     * to ensure consistency across the codebase.
+     */
+    public function __construct()
+    {
+        parent::__construct(HealthCheckerEvents::BEFORE_REPORT_EXPORT_DISPLAY->value);
+    }
+
+    /**
+     * Add HTML content to be displayed before the export report results
+     *
+     * Content should be self-contained with inline styles since the HTML export
+     * is a standalone document without external stylesheets.
+     *
+     * @param   string  $html  HTML content to inject
+     *
+     * @since   3.4.0
+     */
+    public function addHtmlContent(string $html): void
+    {
+        $this->htmlContent[] = $html;
+    }
+
+    /**
+     * Get all HTML content to display
+     *
+     * @return  string  Combined HTML content from all plugins
+     *
+     * @since   3.4.0
+     */
+    public function getHtmlContent(): string
+    {
+        return implode("\n", $this->htmlContent);
+    }
+}

--- a/healthchecker/component/src/Event/HealthCheckerEvents.php
+++ b/healthchecker/component/src/Event/HealthCheckerEvents.php
@@ -70,6 +70,17 @@ enum HealthCheckerEvents: string
     case AFTER_TOOLBAR_BUILD = 'onHealthCheckerAfterToolbarBuild';
 
     /**
+     * Event triggered before the HTML export report is rendered
+     *
+     * Plugins can listen to this event to inject content (banners, notices, etc.)
+     * into the standalone HTML export before it's rendered. Content should be
+     * self-contained with inline styles since the export has no external dependencies.
+     *
+     * @since 3.4.0
+     */
+    case BEFORE_REPORT_EXPORT_DISPLAY = 'onHealthCheckerBeforeReportExportDisplay';
+
+    /**
      * Get the standard handler method name for this event
      *
      * Returns the conventional plugin method name that should handle this event.
@@ -86,6 +97,7 @@ enum HealthCheckerEvents: string
             self::COLLECT_CHECKS => 'onCollectChecks',
             self::BEFORE_REPORT_DISPLAY => 'onBeforeReportDisplay',
             self::AFTER_TOOLBAR_BUILD => 'onAfterToolbarBuild',
+            self::BEFORE_REPORT_EXPORT_DISPLAY => 'onBeforeReportExportDisplay',
         };
     }
 }

--- a/healthchecker/component/src/View/Report/HtmlexportView.php
+++ b/healthchecker/component/src/View/Report/HtmlexportView.php
@@ -13,8 +13,9 @@ namespace MySitesGuru\HealthChecker\Component\Administrator\View\Report;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Plugin\PluginHelper;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
+use MySitesGuru\HealthChecker\Component\Administrator\Event\BeforeReportExportDisplayEvent;
+use MySitesGuru\HealthChecker\Component\Administrator\Event\HealthCheckerEvents;
 
 \defined('_JEXEC') || die;
 
@@ -30,7 +31,7 @@ use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
  * - Summary statistics cards (critical, warning, good, total)
  * - All health check results organized by category
  * - Provider attribution for third-party checks
- * - Optional mySites.guru promotional banner
+ * - Plugin-injected banners via BeforeReportExportDisplayEvent
  * - Print-optimized CSS
  *
  * @since 1.0.0
@@ -77,11 +78,11 @@ class HtmlexportView extends BaseHtmlView
         $goodCount = $model->getGoodCount();
         $totalCount = $model->getTotalCount();
 
-        // Check if mySites.guru plugin is enabled (banner only shows if plugin enabled)
-        $showMySitesGuruBanner = PluginHelper::isEnabled('healthchecker', 'mysitesguru');
-
-        // Get the logo URL (use absolute URL from the site)
-        $logoUrl = \Joomla\CMS\Uri\Uri::root() . 'media/plg_healthchecker_mysitesguru/logo.png';
+        // Dispatch event so plugins can inject banners into the HTML export
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $cmsApplication->getDispatcher()
+            ->dispatch(HealthCheckerEvents::BEFORE_REPORT_EXPORT_DISPLAY->value, $beforeReportExportDisplayEvent);
+        $beforeExportHtml = $beforeReportExportDisplayEvent->getHtmlContent();
 
         header('Content-Type: text/html; charset=utf-8');
         header('Content-Disposition: attachment; filename="health-report-' . date('Y-m-d') . '.html"');
@@ -97,8 +98,7 @@ class HtmlexportView extends BaseHtmlView
             $warningCount,
             $goodCount,
             $totalCount,
-            $showMySitesGuruBanner,
-            $logoUrl,
+            $beforeExportHtml,
         );
 
         $cmsApplication->close();
@@ -121,8 +121,7 @@ class HtmlexportView extends BaseHtmlView
      * @param   int     $warningCount             Count of warning status checks
      * @param   int     $goodCount                Count of good status checks
      * @param   int     $totalCount               Total count of all checks
-     * @param   bool    $showMySitesGuruBanner    Whether to show promotional banner
-     * @param   string  $logoUrl                  Absolute URL to the mySites.guru logo
+     * @param   string  $beforeExportHtml         HTML content injected by plugins via BeforeReportExportDisplayEvent
      *
      * @since   1.0.0
      */
@@ -137,8 +136,7 @@ class HtmlexportView extends BaseHtmlView
         $warningCount,
         $goodCount,
         $totalCount,
-        bool $showMySitesGuruBanner,
-        string $logoUrl,
+        string $beforeExportHtml,
     ): void {
         ?>
 <!DOCTYPE html>
@@ -242,37 +240,6 @@ class HtmlexportView extends BaseHtmlView
         .category-header h2 {
             font-size: 20px;
             color: #495057;
-        }
-
-        .mysites-banner {
-            background: #f8f9fa;
-            border: 1px solid #dee2e6;
-            border-radius: 4px;
-            padding: 15px;
-            margin: 20px 30px;
-            display: flex;
-            align-items: flex-start;
-            gap: 15px;
-        }
-
-        .mysites-banner-icon {
-            flex-shrink: 0;
-        }
-
-        .mysites-banner-content {
-            flex: 1;
-            color: #333;
-            font-size: 14px;
-            line-height: 1.5;
-        }
-
-        .mysites-banner-content a {
-            color: #333;
-            text-decoration: underline;
-        }
-
-        .mysites-banner-content a:hover {
-            color: #000;
         }
 
         .check {
@@ -446,17 +413,13 @@ class HtmlexportView extends BaseHtmlView
             </div>
         </div>
 
-        <?php if ($showMySitesGuruBanner): ?>
-        <div class="mysites-banner">
-            <div class="mysites-banner-icon">
-                <img src="<?php echo htmlspecialchars($logoUrl); ?>" alt="mySites.guru" style="width: 48px; height: 48px; border-radius: 4px;">
-            </div>
-            <div class="mysites-banner-content">
-                This free Health Checker for Joomla is provided free of charge (GPL) by mySites.guru - the original Joomla Health Checker &amp; Joomla Monitoring Dashboard since 2012 - Monitor unlimited sites health from one central dashboard - <a href="https://mysites.guru" target="_blank"><strong>For more details visit mySites.guru</strong></a>
-            </div>
-        </div>
-        <?php endif;
-        ?>
+        <?php if ($beforeExportHtml !== ''): ?>
+            <?php
+            // Security note: This HTML comes from installed Joomla plugins which are trusted code
+            // (they require administrator installation privileges). No user input flows here.
+            echo $beforeExportHtml;
+            ?>
+        <?php endif; ?>
 
         <div class="content">
             <?php foreach ($results as $categorySlug => $categoryResults) {

--- a/healthchecker/plugins/mysitesguru/src/Extension/MySitesGuruPlugin.php
+++ b/healthchecker/plugins/mysitesguru/src/Extension/MySitesGuruPlugin.php
@@ -19,6 +19,7 @@ use Joomla\Event\SubscriberInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Category\HealthCategory;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\AfterToolbarBuildEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\BeforeReportDisplayEvent;
+use MySitesGuru\HealthChecker\Component\Administrator\Event\BeforeReportExportDisplayEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectCategoriesEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectChecksEvent;
 use MySitesGuru\HealthChecker\Component\Administrator\Event\CollectProvidersEvent;
@@ -79,6 +80,7 @@ final class MySitesGuruPlugin extends CMSPlugin implements SubscriberInterface
             HealthCheckerEvents::COLLECT_PROVIDERS->value => HealthCheckerEvents::COLLECT_PROVIDERS->getHandlerMethod(),
             HealthCheckerEvents::BEFORE_REPORT_DISPLAY->value => HealthCheckerEvents::BEFORE_REPORT_DISPLAY->getHandlerMethod(),
             HealthCheckerEvents::AFTER_TOOLBAR_BUILD->value => HealthCheckerEvents::AFTER_TOOLBAR_BUILD->getHandlerMethod(),
+            HealthCheckerEvents::BEFORE_REPORT_EXPORT_DISPLAY->value => HealthCheckerEvents::BEFORE_REPORT_EXPORT_DISPLAY->getHandlerMethod(),
         ];
     }
 
@@ -252,6 +254,38 @@ HTML;
 JS;
 
         $beforeReportDisplayEvent->addHtmlContent($html . "\n" . $js);
+    }
+
+    /**
+     * Inject mySites.guru promotional banner into the HTML export
+     *
+     * Adds a self-contained promotional banner to the HTML export report.
+     * Unlike the admin report banner, this one uses inline styles since
+     * the export is a standalone document with no external CSS.
+     *
+     * @param BeforeReportExportDisplayEvent $beforeReportExportDisplayEvent Event object for injecting HTML content
+     *
+     * @since 3.4.0
+     */
+    public function onBeforeReportExportDisplay(BeforeReportExportDisplayEvent $beforeReportExportDisplayEvent): void
+    {
+        $logoUrl = Uri::root() . 'media/plg_healthchecker_mysitesguru/logo.png';
+        $bannerText = Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT');
+        $bannerLink = Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_LINK');
+
+        $html = <<<HTML
+        <div style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; padding: 15px; margin: 20px 30px; display: flex; align-items: flex-start; gap: 15px;">
+            <div style="flex-shrink: 0;">
+                <img src="{$logoUrl}" alt="mySites.guru" style="width: 48px; height: 48px; border-radius: 4px;">
+            </div>
+            <div style="flex: 1; color: #333; font-size: 14px; line-height: 1.5;">
+                {$bannerText} -
+                <a href="https://mysites.guru" target="_blank" style="color: #333; text-decoration: underline;"><strong>{$bannerLink}</strong></a>
+            </div>
+        </div>
+HTML;
+
+        $beforeReportExportDisplayEvent->addHtmlContent($html);
     }
 
     /**

--- a/tests/Unit/Component/Event/BeforeReportExportDisplayEventTest.php
+++ b/tests/Unit/Component/Event/BeforeReportExportDisplayEventTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright   (C) 2026 https://mySites.guru + Phil E. Taylor <phil@phil-taylor.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @link        https://github.com/mySites-guru/HealthCheckerForJoomla
+ */
+
+namespace HealthChecker\Tests\Unit\Component\Event;
+
+use MySitesGuru\HealthChecker\Component\Administrator\Event\BeforeReportExportDisplayEvent;
+use MySitesGuru\HealthChecker\Component\Administrator\Event\HealthCheckerEvents;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BeforeReportExportDisplayEvent::class)]
+class BeforeReportExportDisplayEventTest extends TestCase
+{
+    public function testEventHasCorrectName(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $this->assertSame(
+            HealthCheckerEvents::BEFORE_REPORT_EXPORT_DISPLAY->value,
+            $beforeReportExportDisplayEvent->getName(),
+        );
+    }
+
+    public function testGetHtmlContentReturnsEmptyStringByDefault(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $this->assertSame('', $beforeReportExportDisplayEvent->getHtmlContent());
+    }
+
+    public function testAddHtmlContentAddsContent(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $beforeReportExportDisplayEvent->addHtmlContent('<div>Test content</div>');
+
+        $this->assertSame('<div>Test content</div>', $beforeReportExportDisplayEvent->getHtmlContent());
+    }
+
+    public function testAddHtmlContentConcatenatesMultipleContents(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $beforeReportExportDisplayEvent->addHtmlContent('<div>First</div>');
+        $beforeReportExportDisplayEvent->addHtmlContent('<div>Second</div>');
+        $beforeReportExportDisplayEvent->addHtmlContent('<div>Third</div>');
+
+        $expected = "<div>First</div>\n<div>Second</div>\n<div>Third</div>";
+        $this->assertSame($expected, $beforeReportExportDisplayEvent->getHtmlContent());
+    }
+
+    public function testAddHtmlContentPreservesOrder(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $beforeReportExportDisplayEvent->addHtmlContent('A');
+        $beforeReportExportDisplayEvent->addHtmlContent('B');
+        $beforeReportExportDisplayEvent->addHtmlContent('C');
+
+        $content = $beforeReportExportDisplayEvent->getHtmlContent();
+        $posA = strpos($content, 'A');
+        $posB = strpos($content, 'B');
+        $posC = strpos($content, 'C');
+
+        $this->assertLessThan($posB, $posA);
+        $this->assertLessThan($posC, $posB);
+    }
+
+    public function testAddHtmlContentAcceptsEmptyString(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $beforeReportExportDisplayEvent->addHtmlContent('');
+
+        $this->assertSame('', $beforeReportExportDisplayEvent->getHtmlContent());
+    }
+
+    public function testEventExtendsJoomlaEvent(): void
+    {
+        $beforeReportExportDisplayEvent = new BeforeReportExportDisplayEvent();
+        $this->assertInstanceOf(\Joomla\Event\Event::class, $beforeReportExportDisplayEvent);
+    }
+}

--- a/tests/Unit/Component/Event/HealthCheckerEventsTest.php
+++ b/tests/Unit/Component/Event/HealthCheckerEventsTest.php
@@ -40,7 +40,7 @@ class HealthCheckerEventsTest extends TestCase
     public function testEnumHasCorrectNumberOfCases(): void
     {
         $cases = HealthCheckerEvents::cases();
-        $this->assertCount(5, $cases);
+        $this->assertCount(6, $cases);
     }
 
     public function testAfterToolbarBuildEventValue(): void

--- a/tests/Unit/Component/View/Report/HtmlexportViewTest.php
+++ b/tests/Unit/Component/View/Report/HtmlexportViewTest.php
@@ -135,8 +135,8 @@ class HtmlexportViewTest extends TestCase
         $reflectionMethod = new \ReflectionMethod(HtmlexportView::class, 'renderHtmlReport');
         $parameters = $reflectionMethod->getParameters();
 
-        // Method has 12 parameters based on the source
-        $this->assertCount(12, $parameters);
+        // Method has 11 parameters based on the source
+        $this->assertCount(11, $parameters);
 
         // Check parameter names
         $paramNames = array_map(
@@ -153,8 +153,7 @@ class HtmlexportViewTest extends TestCase
         $this->assertContains('warningCount', $paramNames);
         $this->assertContains('goodCount', $paramNames);
         $this->assertContains('totalCount', $paramNames);
-        $this->assertContains('showMySitesGuruBanner', $paramNames);
-        $this->assertContains('logoUrl', $paramNames);
+        $this->assertContains('beforeExportHtml', $paramNames);
     }
 
     public function testViewUsesModelForData(): void
@@ -181,12 +180,12 @@ class HtmlexportViewTest extends TestCase
         $this->assertStringContainsString('getResultsByCategory', $source);
     }
 
-    public function testViewUsesPluginHelper(): void
+    public function testViewUsesBeforeReportExportDisplayEvent(): void
     {
         $reflectionClass = new \ReflectionClass(HtmlexportView::class);
         $source = file_get_contents($reflectionClass->getFileName());
 
-        $this->assertStringContainsString('PluginHelper', $source);
+        $this->assertStringContainsString('BeforeReportExportDisplayEvent', $source);
     }
 
     public function testViewUsesHealthStatusEnum(): void

--- a/website/public/docs/developers.md
+++ b/website/public/docs/developers.md
@@ -115,13 +115,40 @@ This developer guide covers:
 
 ## Available Events
 
-Health Checker dispatches three events:
+Health Checker dispatches these events:
 
 | Event | Purpose | When to Use |
 |-------|---------|-------------|
 | `onHealthCheckerCollectChecks` | Register health check instances | Always - this is how you add checks |
 | `onHealthCheckerCollectCategories` | Register custom categories | Only if creating new categories |
 | `onHealthCheckerCollectProviders` | Register provider metadata | Always - provides attribution |
+| `onHealthCheckerBeforeReportDisplay` | Inject HTML into the admin report view | Banners, notices in the admin UI |
+| `onHealthCheckerBeforeReportExportDisplay` | Inject HTML into the standalone HTML export | Banners in downloadable reports |
+| `onHealthCheckerAfterToolbarBuild` | Add custom toolbar buttons | Branded links, extra actions |
+
+### Injecting Banners into HTML Exports
+
+The `onHealthCheckerBeforeReportExportDisplay` event lets plugins add banners or notices to the downloadable HTML export. The export is a self-contained document, so your HTML must use **inline styles** (no external CSS or JavaScript).
+
+```php
+public static function getSubscribedEvents(): array
+{
+    return [
+        'onHealthCheckerBeforeReportExportDisplay' => 'onBeforeReportExportDisplay',
+    ];
+}
+
+public function onBeforeReportExportDisplay(BeforeReportExportDisplayEvent $event): void
+{
+    $html = '<div style="background: #f0f8ff; padding: 15px; margin: 20px 30px; border-radius: 4px;">'
+        . 'Your promotional or informational content here'
+        . '</div>';
+
+    $event->addHtmlContent($html);
+}
+```
+
+The banner renders between the summary statistics and the check results. Multiple plugins can each contribute a banner — they appear in subscription order.
 
 ## Provider Attribution
 


### PR DESCRIPTION
## Summary

Closes #52.

The HTML export had mySites.guru's promotional banner hardcoded directly in `HtmlexportView`. This meant no other plugin could inject banners into exports.

This PR adds a `BeforeReportExportDisplayEvent` (mirrors the existing `BeforeReportDisplayEvent` for the admin UI) so any plugin can contribute banners to the downloadable HTML report. The mySites.guru banner now uses this event instead of being hardcoded.

### What changed

- **New `BeforeReportExportDisplayEvent`** — plugins subscribe to `onHealthCheckerBeforeReportExportDisplay` and call `addHtmlContent()` with self-contained HTML (inline styles required since the export is standalone)
- **New enum case** `BEFORE_REPORT_EXPORT_DISPLAY` in `HealthCheckerEvents`
- **`HtmlexportView`** dispatches the event and renders whatever plugins provide, replacing the old `PluginHelper::isEnabled()` check and hardcoded banner HTML/CSS
- **`MySitesGuruPlugin`** now handles `onBeforeReportExportDisplay` with its banner using inline styles
- **Developer docs** updated with the new event and a usage example
- **Tests** added for the new event class; existing tests updated for the signature changes

## Test plan

- [x] Run `composer check` — all quality checks pass
- [x] Export HTML report with mySites.guru plugin enabled — banner appears
- [x] Export HTML report with mySites.guru plugin disabled — no banner
- [x] Verify the exported HTML is self-contained (no broken styles)