### PR TITLE
Add per-check export visibility settings

### DIFF
--- a/docs/USER/exporting-reports.md
+++ b/docs/USER/exporting-reports.md
@@ -173,6 +173,37 @@ cp health-check-report-2026-01-12.html \
    compliance/2026/01/monthly-health-check.html
 ```
 
+## Per-Check Export Visibility
+
+Export visibility lets you exclude specific checks from exports without disabling them. The check still runs and appears in the admin UI — it just won't appear in exported JSON or HTML reports.
+
+This is useful when sharing reports with clients or external parties and you want to omit checks that aren't relevant to them (such as server-level configuration checks) or checks that always pass and add noise.
+
+### Configuring Export Visibility
+
+1. Go to **Extensions → Plugins**
+2. Open the plugin that provides the check (e.g., "Health Checker - Core Checks")
+3. Find the check in the configuration list
+4. Set the **Export Visibility** dropdown next to the check
+
+### Visibility Modes
+
+| Option | Behaviour |
+|---|---|
+| **Always Export** | Included in every export regardless of result (default) |
+| **Issues Only** | Included only when the result is Warning or Critical |
+| **Never Export** | Never included in exports |
+
+### Common Use Cases
+
+- **Client reports**: Set server-environment checks (PHP version, MySQL config) to "Never Export" so clients only see application-level issues that need their attention
+- **Noise reduction**: Set checks that consistently pass (e.g., a check you've already resolved) to "Issues Only" to keep reports focused
+- **Example/demo checks**: Set any placeholder checks to "Never Export" so they don't appear in production reports
+
+### How It Affects Exports
+
+The export summary counts only the checks included in the export. A check set to "Never Export" does not affect the critical/warning/good totals shown in the report header.
+
 ## Export Tips
 
 ### When to Export

--- a/docs/USER/guide/managing-checks.md
+++ b/docs/USER/guide/managing-checks.md
@@ -102,6 +102,38 @@ If you only care about security monitoring:
 2. Disable checks in other categories as needed
 3. This reduces execution time and focuses reports on security issues only
 
+## Controlling Export Visibility
+
+Beyond enabling or disabling a check entirely, you can control whether each check appears in exported reports. This lets a check continue running and showing results in the admin UI while keeping it out of the reports you share with clients or hosting providers.
+
+### How to Configure It
+
+Each check in the plugin configuration has an **Export Visibility** dropdown alongside the enable/disable toggle:
+
+1. Go to **Extensions → Plugins** and open the plugin
+2. Find the check you want to configure
+3. Set the **Export Visibility** dropdown:
+   - **Always Export** — included in every export (default for all checks)
+   - **Issues Only** — only included when the result is Warning or Critical
+   - **Never Export** — excluded from all exports
+4. Click **Save & Close**
+
+The check continues to run and its result is visible in the Health Checker dashboard. Only the export output is affected.
+
+### Example: Preparing a Client Report
+
+You manage a site for a client and want to send them an HTML report covering only application-level issues. Server configuration checks (PHP memory limits, MySQL settings) are things you handle on their behalf — there's no reason to include them in a client-facing report.
+
+1. Open the Core Checks plugin configuration
+2. In the **System & Hosting Checks** section, set the export visibility for server-level checks to **Never Export**
+3. Export the HTML report — it will contain only the checks relevant to the client
+
+### Notes
+
+- Export visibility has no effect on the admin dashboard — all enabled checks always appear there
+- The summary totals in an exported report (critical/warning/good counts) reflect only the checks that are included in that export
+- "Issues Only" is a good default for informational checks that rarely fail — the exported report stays focused on problems without losing those checks when they do trigger
+
 ## Impact on Performance
 
 Disabled checks are **completely skipped** during execution:

--- a/healthchecker/component/src/Check/AbstractHealthCheck.php
+++ b/healthchecker/component/src/Check/AbstractHealthCheck.php
@@ -57,6 +57,17 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
     protected ?Http $httpClient = null;
 
     /**
+     * Export visibility override set via plugin configuration.
+     *
+     * When set, this takes precedence over the value returned by
+     * getExportVisibility(). Set via setExportVisibility() by plugin
+     * event handlers that read export config from XML params.
+     *
+     * @since 3.4.0
+     */
+    private ?ExportVisibility $exportVisibility = null;
+
+    /**
      * Inject the Joomla database instance for use in database-dependent checks.
      *
      * This method is called by the HealthCheckRunner service before executing
@@ -233,6 +244,37 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
     }
 
     /**
+     * Get the export visibility mode for this check.
+     *
+     * Returns the config override if set via setExportVisibility(), otherwise
+     * returns the default (Always). Third-party plugins can override this method
+     * to return a different default for their checks.
+     *
+     * @return ExportVisibility The export visibility mode
+     *
+     * @since 3.4.0
+     */
+    public function getExportVisibility(): ExportVisibility
+    {
+        return $this->exportVisibility ?? ExportVisibility::Always;
+    }
+
+    /**
+     * Override the export visibility from plugin configuration.
+     *
+     * Called by plugin event handlers after reading the export visibility
+     * setting from XML params. This takes precedence over the class default.
+     *
+     * @param ExportVisibility $exportVisibility The visibility mode from config
+     *
+     * @since 3.4.0
+     */
+    public function setExportVisibility(ExportVisibility $exportVisibility): void
+    {
+        $this->exportVisibility = $exportVisibility;
+    }
+
+    /**
      * Get the human-readable translated title for this check.
      *
      * Automatically derives a language key from the slug and attempts to translate it.
@@ -316,6 +358,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(HealthStatus::Critical),
             actionUrl: $this->getActionUrl(HealthStatus::Critical),
+            exportVisibility: $this->getExportVisibility(),
         );
     }
 
@@ -343,6 +386,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(HealthStatus::Warning),
             actionUrl: $this->getActionUrl(HealthStatus::Warning),
+            exportVisibility: $this->getExportVisibility(),
         );
     }
 
@@ -369,6 +413,7 @@ abstract class AbstractHealthCheck implements HealthCheckInterface
             provider: $this->getProvider(),
             docsUrl: $this->getDocsUrl(HealthStatus::Good),
             actionUrl: $this->getActionUrl(HealthStatus::Good),
+            exportVisibility: $this->getExportVisibility(),
         );
     }
 }

--- a/healthchecker/component/src/Check/ExportVisibility.php
+++ b/healthchecker/component/src/Check/ExportVisibility.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright   (C) 2026 https://mySites.guru + Phil E. Taylor <phil@phil-taylor.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @link        https://github.com/mySites-guru/HealthCheckerForJoomla
+ */
+
+namespace MySitesGuru\HealthChecker\Component\Administrator\Check;
+
+\defined('_JEXEC') || die;
+
+/**
+ * Export visibility modes for health checks.
+ *
+ * Controls whether a health check result is included in exported reports
+ * (HTML export, JSON export). This is independent of whether the check
+ * is enabled — a check can run and appear in the admin UI but be excluded
+ * from exports.
+ *
+ * The visibility can be set in two ways:
+ * 1. Override getExportVisibility() in the check class (developer default)
+ * 2. Configure via plugin XML params (admin override)
+ *
+ * @since 3.4.0
+ */
+enum ExportVisibility: string
+{
+    /**
+     * Always include this check in exports regardless of status.
+     * This is the default for all checks.
+     */
+    case Always = 'always';
+
+    /**
+     * Only include this check in exports when the result is Warning or Critical.
+     * Good results are excluded from exports.
+     */
+    case IssuesOnly = 'issues';
+
+    /**
+     * Never include this check in exports regardless of status.
+     * The check still runs and appears in the admin UI.
+     */
+    case Never = 'never';
+}

--- a/healthchecker/component/src/Check/HealthCheckInterface.php
+++ b/healthchecker/component/src/Check/HealthCheckInterface.php
@@ -87,4 +87,17 @@ interface HealthCheckInterface
      * @since 1.0.0
      */
     public function run(): HealthCheckResult;
+
+    /**
+     * Get the export visibility mode for this check.
+     *
+     * Controls whether this check's result is included in exported reports.
+     * Default is Always (included in all exports). Override in your check class
+     * to change the default, or use setExportVisibility() to override from config.
+     *
+     * @return ExportVisibility The export visibility mode
+     *
+     * @since 3.4.0
+     */
+    public function getExportVisibility(): ExportVisibility;
 }

--- a/healthchecker/component/src/Check/HealthCheckResult.php
+++ b/healthchecker/component/src/Check/HealthCheckResult.php
@@ -127,6 +127,18 @@ final class HealthCheckResult
          * @since 3.0.36
          */
         public readonly ?string $actionUrl = null,
+
+        /**
+         * Export visibility mode for this check result.
+         *
+         * Controls whether this result is included in exported reports.
+         * Always = include in all exports, IssuesOnly = only when warning/critical,
+         * Never = excluded from all exports.
+         *
+         * @var ExportVisibility The export visibility mode
+         * @since 3.4.0
+         */
+        public readonly ExportVisibility $exportVisibility = ExportVisibility::Always,
     ) {}
 
     /**
@@ -137,7 +149,7 @@ final class HealthCheckResult
      * string value. The title has all HTML stripped for security, while the
      * description is sanitized to allow only safe HTML formatting tags.
      *
-     * @return array{status: string, title: string, description: string, slug: string, category: string, provider: string, docsUrl: string|null, actionUrl: string|null}
+     * @return array{status: string, title: string, description: string, slug: string, category: string, provider: string, docsUrl: string|null, actionUrl: string|null, exportVisibility: string}
      *               Array representation of the result
      *
      * @since 1.0.0
@@ -155,6 +167,7 @@ final class HealthCheckResult
             'provider' => $this->provider,
             'docsUrl' => $this->docsUrl,
             'actionUrl' => $this->actionUrl,
+            'exportVisibility' => $this->exportVisibility->value,
         ];
     }
 
@@ -187,7 +200,7 @@ final class HealthCheckResult
      * This is used to reconstruct HealthCheckResult objects from cached JSON data.
      * It's the inverse of toArray() and provides a safe alternative to unserialize().
      *
-     * @param array{status: string, title: string, description: string, slug: string, category: string, provider?: string, docsUrl?: string|null, actionUrl?: string|null} $data
+     * @param array{status: string, title: string, description: string, slug: string, category: string, provider?: string, docsUrl?: string|null, actionUrl?: string|null, exportVisibility?: string} $data
      *               Array representation of the result (as produced by toArray())
      *
      * @return self The reconstructed HealthCheckResult object
@@ -205,6 +218,9 @@ final class HealthCheckResult
             provider: $data['provider'] ?? 'core',
             docsUrl: $data['docsUrl'] ?? null,
             actionUrl: $data['actionUrl'] ?? null,
+            exportVisibility: isset($data['exportVisibility']) ? ExportVisibility::from(
+                $data['exportVisibility'],
+            ) : ExportVisibility::Always,
         );
     }
 }

--- a/healthchecker/component/src/Service/HealthCheckRunner.php
+++ b/healthchecker/component/src/Service/HealthCheckRunner.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\ExportVisibility;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
@@ -467,6 +468,67 @@ final class HealthCheckRunner
         }
 
         return $grouped;
+    }
+
+    /**
+     * Get results filtered by export visibility.
+     *
+     * Filters the results based on each result's exportVisibility setting:
+     * - Always: included in exports regardless of status
+     * - IssuesOnly: included only if status is Warning or Critical
+     * - Never: excluded from exports
+     *
+     * @return HealthCheckResult[] Filtered array of exportable results
+     *
+     * @since 3.4.0
+     */
+    public function getExportableResults(): array
+    {
+        return array_values(array_filter(
+            $this->results,
+            static fn(HealthCheckResult $healthCheckResult): bool => match ($healthCheckResult->exportVisibility) {
+                ExportVisibility::Always => true,
+                ExportVisibility::IssuesOnly => $healthCheckResult->healthStatus !== HealthStatus::Good,
+                ExportVisibility::Never => false,
+            },
+        ));
+    }
+
+    /**
+     * Get exportable results grouped by category in category sort order.
+     *
+     * Same as getResultsByCategory() but filtered by export visibility.
+     * Empty categories (after filtering) are excluded.
+     *
+     * @return array<string, HealthCheckResult[]> Category slug => array of exportable results
+     *
+     * @since 3.4.0
+     */
+    public function getExportableResultsByCategory(): array
+    {
+        $exportable = $this->getExportableResults();
+        $grouped = [];
+
+        foreach ($exportable as $result) {
+            $grouped[$result->category][] = $result;
+        }
+
+        $sortedCategories = $this->categoryRegistry->getSorted();
+        $sorted = [];
+
+        foreach ($sortedCategories as $sortedCategory) {
+            if (isset($grouped[$sortedCategory->slug])) {
+                $sorted[$sortedCategory->slug] = $grouped[$sortedCategory->slug];
+            }
+        }
+
+        foreach ($grouped as $slug => $results) {
+            if (! isset($sorted[$slug])) {
+                $sorted[$slug] = $results;
+            }
+        }
+
+        return $sorted;
     }
 
     /**

--- a/healthchecker/component/src/View/Report/HtmlexportView.php
+++ b/healthchecker/component/src/View/Report/HtmlexportView.php
@@ -60,7 +60,7 @@ class HtmlexportView extends BaseHtmlView
         $model = $this->getModel();
         $model->runChecks();
 
-        $results = $model->getResultsByCategory();
+        $results = $model->getExportableResultsByCategory();
         $categories = $model->getRunner()
             ->getCategoryRegistry()
             ->all();
@@ -72,10 +72,11 @@ class HtmlexportView extends BaseHtmlView
         $reportDate = date('F j, Y \a\t g:i A');
         $joomlaVersion = JVERSION;
 
-        $criticalCount = $model->getCriticalCount();
-        $warningCount = $model->getWarningCount();
-        $goodCount = $model->getGoodCount();
-        $totalCount = $model->getTotalCount();
+        $exportCounts = $model->getExportableCounts();
+        $criticalCount = $exportCounts['critical'];
+        $warningCount = $exportCounts['warning'];
+        $goodCount = $exportCounts['good'];
+        $totalCount = $exportCounts['total'];
 
         // Check if mySites.guru plugin is enabled (banner only shows if plugin enabled)
         $showMySitesGuruBanner = PluginHelper::isEnabled('healthchecker', 'mysitesguru');

--- a/healthchecker/component/src/View/Report/JsonView.php
+++ b/healthchecker/component/src/View/Report/JsonView.php
@@ -59,7 +59,7 @@ class JsonView extends BaseJsonView
         header('Content-Type: application/json; charset=utf-8');
         header('Content-Disposition: attachment; filename="health-report-' . date('Y-m-d') . '.json"');
 
-        echo $model->toJson();
+        echo $model->toExportJson();
 
         $cmsApplication->close();
     }

--- a/healthchecker/plugins/core/core.xml
+++ b/healthchecker/plugins/core/core.xml
@@ -53,6 +53,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_apache_modules"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_core_directories"
@@ -63,6 +74,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_core_directories"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -75,6 +97,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_curl_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_disk_space"
@@ -85,6 +118,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_disk_space"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -97,6 +141,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_dom_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_exif_extension"
@@ -107,6 +162,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_exif_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -119,6 +185,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_failed_tasks"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_fileinfo_extension"
@@ -129,6 +206,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_fileinfo_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -141,6 +229,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_gd_or_imagick"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_imagick_version"
@@ -151,6 +250,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_imagick_version"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -163,6 +273,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_intl_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_json_extension"
@@ -173,6 +294,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_json_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -185,6 +317,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_log_file_size"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_mail_function"
@@ -195,6 +338,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_mail_function"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -207,6 +361,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_max_execution_time"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_max_input_time"
@@ -217,6 +382,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_max_input_time"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -229,6 +405,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_max_input_vars"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_mbstring_extension"
@@ -239,6 +426,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_mbstring_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -251,6 +449,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_memory_limit"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_opcache"
@@ -261,6 +470,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_opcache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -273,6 +493,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_openssl_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_output_buffering"
@@ -283,6 +514,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_output_buffering"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -295,6 +537,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_overdue_tasks"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_pdo_mysql_extension"
@@ -305,6 +558,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_pdo_mysql_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -317,6 +581,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_php_eol"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_php_sapi"
@@ -327,6 +602,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_php_sapi"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -339,6 +625,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_php_version"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_post_max_size"
@@ -349,6 +646,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_post_max_size"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -361,6 +669,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_realpath_cache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_server_time"
@@ -371,6 +690,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_server_time"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -383,6 +713,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_session_save_path"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_simplexml_extension"
@@ -393,6 +734,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_simplexml_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -405,6 +757,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_temp_directory"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_upload_max_filesize"
@@ -416,6 +779,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_system_upload_max_filesize"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_system_zip_extension"
@@ -426,6 +800,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_system_zip_extension"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Database -->
@@ -447,6 +832,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_auto_increment"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_connection_charset"
@@ -457,6 +853,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_connection_charset"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -469,6 +876,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_connection"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_index_usage"
@@ -479,6 +897,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_index_usage"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -491,6 +920,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_max_packet"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_orphaned_tables"
@@ -501,6 +941,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_orphaned_tables"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -513,6 +964,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_server_version"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_size"
@@ -523,6 +985,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_size"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -535,6 +1008,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_slow_query"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_sql_mode"
@@ -545,6 +1029,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_sql_mode"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -557,6 +1052,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_table_charset"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_table_engine"
@@ -567,6 +1073,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_table_engine"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -579,6 +1096,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_table_prefix"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_table_status"
@@ -589,6 +1117,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_table_status"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -601,6 +1140,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_transaction_isolation"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_user_privileges"
@@ -612,6 +1162,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_database_user_privileges"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_database_wait_timeout"
@@ -622,6 +1183,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_database_wait_timeout"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Security -->
@@ -643,6 +1215,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_action_logs_enabled"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_admin_path"
@@ -653,6 +1236,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_admin_path"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -665,6 +1259,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_admin_username"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_api_auth"
@@ -675,6 +1280,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_api_auth"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -687,6 +1303,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_brute_force_protection"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_configuration_php_permissions"
@@ -697,6 +1324,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_configuration_php_permissions"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -709,6 +1347,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_content_security_policy"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_cors"
@@ -719,6 +1368,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_cors"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -731,6 +1391,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_debug_mode"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_default_secret"
@@ -741,6 +1412,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_default_secret"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -753,6 +1435,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_error_reporting"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_force_ssl"
@@ -763,6 +1456,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_force_ssl"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -775,6 +1479,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_htaccess_protection"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_index_file"
@@ -785,6 +1500,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_index_file"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -797,6 +1523,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_https_redirect"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_mailer_security"
@@ -807,6 +1544,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_mailer_security"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -819,6 +1567,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_password_policy"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_privacy_dashboard"
@@ -829,6 +1588,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_privacy_dashboard"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -841,6 +1611,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_recaptcha"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_session_handler"
@@ -851,6 +1632,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_session_handler"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -863,6 +1655,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_session_lifetime"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_two_factor_auth"
@@ -874,6 +1677,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_security_two_factor_auth"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_security_x_frame_options"
@@ -884,6 +1698,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_security_x_frame_options"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Users -->
@@ -905,6 +1730,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_admin_email"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_blocked_users"
@@ -915,6 +1751,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_blocked_users"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -927,6 +1774,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_default_user_group"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_duplicate_emails"
@@ -937,6 +1795,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_duplicate_emails"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -949,6 +1818,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_inactive_users"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_last_login"
@@ -959,6 +1839,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_last_login"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -971,6 +1862,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_password_expiry"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_super_admin_count"
@@ -981,6 +1883,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_super_admin_count"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -993,6 +1906,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_user_fields"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_user_groups"
@@ -1003,6 +1927,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_user_groups"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1015,6 +1950,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_users_user_notes"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_users_user_registration"
@@ -1025,6 +1971,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_users_user_registration"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Extensions -->
@@ -1046,6 +2003,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_cache_plugin"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_disabled_extensions"
@@ -1056,6 +2024,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_disabled_extensions"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1068,6 +2047,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_joomla_core_version"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_language_packs"
@@ -1078,6 +2068,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_language_packs"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1090,6 +2091,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_missing_updates"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_module_positions"
@@ -1100,6 +2112,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_module_positions"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1112,6 +2135,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_overrides"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_plugin_order"
@@ -1122,6 +2156,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_plugin_order"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1134,6 +2179,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_search_plugins"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_template"
@@ -1144,6 +2200,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_template"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1156,6 +2223,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_extensions_unused_modules"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_extensions_update_sites"
@@ -1166,6 +2244,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_extensions_update_sites"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Performance -->
@@ -1187,6 +2276,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_browser_cache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_css_minify"
@@ -1197,6 +2297,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_performance_css_minify"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1209,6 +2320,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_database_query_cache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_gzip_compression"
@@ -1219,6 +2341,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_performance_gzip_compression"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1231,6 +2364,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_image_optimization"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_js_minify"
@@ -1241,6 +2385,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_performance_js_minify"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1253,6 +2408,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_lazy_load"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_page_cache"
@@ -1263,6 +2429,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_performance_page_cache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1275,6 +2452,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_redirects"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_smart_search_index"
@@ -1286,6 +2474,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_performance_smart_search_index"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_performance_system_cache"
@@ -1296,6 +2495,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_performance_system_cache"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- SEO -->
@@ -1317,6 +2527,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_alt_text"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_broken_links"
@@ -1327,6 +2548,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_seo_broken_links"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1339,6 +2571,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_canonical_url"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_meta_keywords"
@@ -1349,6 +2592,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_seo_meta_keywords"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1361,6 +2615,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_open_graph"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_robots_file"
@@ -1371,6 +2636,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_seo_robots_file"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1383,6 +2659,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_sef_urls"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_sitemap"
@@ -1393,6 +2680,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_seo_sitemap"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1405,6 +2703,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_site_meta_description"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_structured_data"
@@ -1416,6 +2725,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_seo_structured_data"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_seo_twitter_cards"
@@ -1426,6 +2746,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_seo_twitter_cards"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <!-- Content Quality -->
@@ -1447,6 +2778,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_archived_content"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_category_depth"
@@ -1457,6 +2799,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_content_category_depth"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1469,6 +2822,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_draft_articles"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_empty_articles"
@@ -1479,6 +2843,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_content_empty_articles"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1491,6 +2866,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_expired_content"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_menu_orphans"
@@ -1501,6 +2887,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_content_menu_orphans"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1513,6 +2910,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_orphaned_articles"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_scheduled_content"
@@ -1523,6 +2931,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_content_scheduled_content"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
                 <field
@@ -1535,6 +2954,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_trashed_content"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_uncategorized_content"
@@ -1546,6 +2976,17 @@
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
                 </field>
+                <field
+                    name="export_content_uncategorized_content"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
+                </field>
 
                 <field
                     name="check_content_unpublished_category_articles"
@@ -1556,6 +2997,17 @@
                 >
                     <option value="1">JENABLED</option>
                     <option value="0">JDISABLED</option>
+                </field>
+                <field
+                    name="export_content_unpublished_category_articles"
+                    type="list"
+                    label="PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY"
+                    default="always"
+                    class="form-select-sm"
+                >
+                    <option value="always">PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS</option>
+                    <option value="issues">PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY</option>
+                    <option value="never">PLG_HEALTHCHECKER_CORE_EXPORT_NEVER</option>
                 </field>
 
             </fieldset>

--- a/healthchecker/plugins/core/language/en-GB/plg_healthchecker_core.ini
+++ b/healthchecker/plugins/core/language/en-GB/plg_healthchecker_core.ini
@@ -5,6 +5,12 @@
 PLG_HEALTHCHECKER_CORE="Health Checker - Core Checks"
 PLG_HEALTHCHECKER_CORE_XML_DESCRIPTION="Provides the core health checks for Health Checker for Joomla."
 
+; Export Visibility
+PLG_HEALTHCHECKER_CORE_EXPORT_VISIBILITY="Export Visibility"
+PLG_HEALTHCHECKER_CORE_EXPORT_ALWAYS="Always Export"
+PLG_HEALTHCHECKER_CORE_EXPORT_ISSUES_ONLY="Issues Only"
+PLG_HEALTHCHECKER_CORE_EXPORT_NEVER="Never Export"
+
 ; Plugin Configuration
 PLG_HEALTHCHECKER_CORE_FIELDSET_CHECKS_LABEL="Health Checks"
 PLG_HEALTHCHECKER_CORE_FIELDSET_CHECKS_DESC="Enable or disable individual health checks. Disabled checks will not execute, improving performance."

--- a/tests/Unit/Component/Service/HealthCheckRunnerExtendedTest.php
+++ b/tests/Unit/Component/Service/HealthCheckRunnerExtendedTest.php
@@ -13,6 +13,7 @@ namespace HealthChecker\Tests\Unit\Component\Service;
 use Joomla\Database\DatabaseInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Category\HealthCategory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\ExportVisibility;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckInterface;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
@@ -332,6 +333,11 @@ class HealthCheckRunnerExtendedTest extends TestCase
             public function run(): HealthCheckResult
             {
                 throw new \RuntimeException('Check exploded!');
+            }
+
+            public function getExportVisibility(): ExportVisibility
+            {
+                return ExportVisibility::Always;
             }
         };
 
@@ -927,6 +933,11 @@ class HealthCheckRunnerExtendedTest extends TestCase
                     category: $this->category,
                     provider: $this->getProvider(),
                 );
+            }
+
+            public function getExportVisibility(): ExportVisibility
+            {
+                return ExportVisibility::Always;
             }
         };
     }

--- a/tests/Unit/Component/View/Report/HtmlexportViewTest.php
+++ b/tests/Unit/Component/View/Report/HtmlexportViewTest.php
@@ -178,7 +178,7 @@ class HtmlexportViewTest extends TestCase
         $reflectionMethod = new \ReflectionMethod(HtmlexportView::class, 'display');
         $source = file_get_contents($reflectionMethod->getFileName());
 
-        $this->assertStringContainsString('getResultsByCategory', $source);
+        $this->assertStringContainsString('getExportableResultsByCategory', $source);
     }
 
     public function testViewUsesPluginHelper(): void

--- a/tests/Unit/Component/View/Report/JsonViewTest.php
+++ b/tests/Unit/Component/View/Report/JsonViewTest.php
@@ -137,6 +137,6 @@ class JsonViewTest extends TestCase
         $reflectionMethod = new \ReflectionMethod(JsonView::class, 'display');
         $source = file_get_contents($reflectionMethod->getFileName());
 
-        $this->assertStringContainsString('toJson', $source);
+        $this->assertStringContainsString('toExportJson', $source);
     }
 }


### PR DESCRIPTION
## Summary
- Add `ExportVisibility` enum (`Always`/`IssuesOnly`/`Never`) so checks can be excluded from exports without disabling them
- Plugin authors override `getExportVisibility()` to set defaults for their checks
- Admins override per-check via plugin XML config (dropdown alongside enable/disable toggle)
- Export views (HTML + JSON) filter results via `getExportableResults()` — summary counts reflect only included checks

## Test plan
- [x] Run `composer check` (ECS, Rector, PHPStan level 8, PHPUnit) — all pass
- [x] Verify new ExportVisibility enum works with all three modes
- [x] Set a check to "Never Export" in plugin config, export HTML/JSON, confirm it's excluded
- [x] Set a check to "Issues Only", run with Good result, confirm excluded from export
- [x] Set a check to "Issues Only", run with Warning result, confirm included in export
- [x] Verify export summary counts reflect only exported checks
- [x] Review updated documentation (exporting-reports, creating-checks, api-reference, managing-checks)

Closes #51