### PR TITLE
Switch export from GET to POST to fix 414 URI Too Long

### DIFF
--- a/healthchecker/component/tmpl/export/default.php
+++ b/healthchecker/component/tmpl/export/default.php
@@ -43,7 +43,7 @@ Text::script('COM_HEALTHCHECKER_ERROR');
      data-export-html-url="<?php echo htmlspecialchars($htmlUrl); ?>"
      data-export-markdown-url="<?php echo htmlspecialchars($markdownUrl); ?>"
 >
-    <form id="exportForm" method="post" target="_blank">
+    <form id="exportForm" method="post">
         <input type="hidden" name="<?php echo htmlspecialchars($token); ?>" value="1">
 
         <div class="row">


### PR DESCRIPTION
## Summary
- Export was passing all selected categories and checks as URL query parameters, which exceeded server URI length limits when many checks were selected (especially with third-party plugins installed)
- Switched the JavaScript form submission from building a GET URL to submitting a dynamically created POST form, moving filter data into the request body
- No PHP changes needed — Joomla's Input class already reads POST data

Fixes #58