### PR TITLE
Add action URLs to Extensions category checks

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php
@@ -71,6 +71,15 @@ final class CachePluginCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/CachePluginCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_plugins&view=plugins&filter[folder]=system&filter[element]=cache';
+        }
+
+        return null;
+    }
+
     /**
      * Performs the cache plugin health check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php
@@ -66,6 +66,15 @@ final class DisabledExtensionsCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/DisabledExtensionsCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_installer&view=manage&filter[status]=0';
+        }
+
+        return null;
+    }
+
     /**
      * Performs the disabled extensions health check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php
@@ -65,6 +65,11 @@ final class LanguagePacksCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/LanguagePacksCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): string
+    {
+        return '/administrator/index.php?option=com_installer&view=languages';
+    }
+
     /**
      * Performs the language packs health check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php
@@ -67,6 +67,15 @@ final class MissingUpdatesCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/MissingUpdatesCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning || $healthStatus === HealthStatus::Critical) {
+            return '/administrator/index.php?option=com_installer&view=update';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the missing updates check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php
@@ -68,6 +68,15 @@ final class ModulePositionCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/ModulePositionCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_modules&view=modules&client_id=0';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the module position check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php
@@ -74,6 +74,15 @@ final class OverrideCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/OverrideCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_templates&view=templates&client_id=0';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the template override check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php
@@ -69,6 +69,15 @@ final class PluginOrderCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/PluginOrderCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_plugins&view=plugins&filter[folder]=system';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the plugin order check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php
@@ -68,6 +68,15 @@ final class SearchPluginsCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/SearchPluginsCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_plugins&view=plugins&filter[folder]=finder';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the search plugins check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php
@@ -68,6 +68,15 @@ final class TemplateCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/TemplateCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Critical) {
+            return '/administrator/index.php?option=com_templates&view=templates';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the template integrity check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php
@@ -71,6 +71,15 @@ final class UnusedModulesCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/UnusedModulesCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_modules&view=modules&client_id=0';
+        }
+
+        return null;
+    }
+
     /**
      * Perform the unused modules check.
      *

--- a/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php
@@ -67,6 +67,15 @@ final class UpdateSitesCheck extends AbstractHealthCheck
         return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/UpdateSitesCheck.php';
     }
 
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_installer&view=updatesites';
+        }
+
+        return null;
+    }
+
     /**
      * Performs the update sites health check.
      *


### PR DESCRIPTION
## Summary

- Added `getActionUrl()` to all 11 Extensions category checks that were missing them
- Each check result now links directly to the relevant Joomla admin page where the user can take action (e.g., plugin manager, update manager, template manager)
- URLs are simplified to essential parameters only — no column/ordering/limit noise

### Checks updated

| Check | Links to | Shown on |
|-------|---------|----------|
| CachePlugin | System plugins (cache filter) | Warning |
| DisabledExtensions | Extension Manager (disabled filter) | Warning |
| LanguagePacks | Language installer | Always |
| MissingUpdates | Extension updates | Warning/Critical |
| ModulePosition | Site modules | Warning |
| Override | Site templates | Warning |
| PluginOrder | System plugins | Warning |
| SearchPlugins | Finder plugins | Warning |
| Template | Template manager | Critical |
| UnusedModules | Site modules | Warning |
| UpdateSites | Update sites manager | Warning |

Closes #62

## Test plan

- [x] Verify each check's action URL opens the correct admin page
- [x] Confirm URLs only appear on the appropriate status (not on Good where irrelevant)
- [x] Run `composer check` — all passing