### PR TITLE
Include site domain in export filenames

### DIFF
--- a/healthchecker/component/src/Model/ReportModel.php
+++ b/healthchecker/component/src/Model/ReportModel.php
@@ -12,6 +12,7 @@ namespace MySitesGuru\HealthChecker\Component\Administrator\Model;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 use MySitesGuru\HealthChecker\Component\Administrator\Extension\HealthCheckerComponent;
@@ -42,6 +43,37 @@ class ReportModel extends BaseDatabaseModel
      * @since 1.0.0
      */
     private ?HealthCheckRunner $healthCheckRunner = null;
+
+    /**
+     * Generate an export filename that includes the site domain
+     *
+     * Extracts the domain from the Joomla site URL and includes it in the filename
+     * so exports from different sites are easily distinguishable when saved to the
+     * same folder.
+     *
+     * Example: health-report-example-com-2026-02-28.json
+     *
+     * @param   string  $extension  File extension without dot (e.g. 'json', 'html', 'md')
+     *
+     * @return  string  The filename string (without path)
+     *
+     * @since   4.0.0
+     */
+    public static function getExportFilename(string $extension): string
+    {
+        $host = parse_url(Uri::root(), PHP_URL_HOST);
+
+        if (! \is_string($host) || $host === '') {
+            $host = 'localhost';
+        }
+
+        // Sanitize: lowercase, replace non-alphanumeric chars with hyphens, collapse and trim
+        $slug = strtolower($host);
+        $slug = (string) preg_replace('/[^a-z0-9]+/', '-', $slug);
+        $slug = trim($slug, '-');
+
+        return 'health-report-' . $slug . '-' . date('Y-m-d') . '.' . $extension;
+    }
 
     /**
      * Execute all registered health checks

--- a/healthchecker/component/src/View/Report/HtmlexportView.php
+++ b/healthchecker/component/src/View/Report/HtmlexportView.php
@@ -45,7 +45,7 @@ class HtmlexportView extends BaseHtmlView
      * HTML document with embedded styles. The document is sent as a downloadable file
      * with appropriate headers.
      *
-     * Filename format: health-report-YYYY-MM-DD.html
+     * Filename format: health-report-{domain}-YYYY-MM-DD.html
      *
      * This method terminates the application after sending the response.
      *
@@ -98,7 +98,7 @@ class HtmlexportView extends BaseHtmlView
         $beforeExportHtml = $beforeReportExportDisplayEvent->getHtmlContent();
 
         header('Content-Type: text/html; charset=utf-8');
-        header('Content-Disposition: attachment; filename="health-report-' . date('Y-m-d') . '.html"');
+        header('Content-Disposition: attachment; filename="' . $model::getExportFilename('html') . '"');
 
         $this->renderHtmlReport(
             $results,

--- a/healthchecker/component/src/View/Report/JsonView.php
+++ b/healthchecker/component/src/View/Report/JsonView.php
@@ -40,7 +40,7 @@ class JsonView extends BaseJsonView
      * Executes all health checks, formats the complete report as JSON, and sends
      * it as a downloadable file with appropriate headers.
      *
-     * Filename format: health-report-YYYY-MM-DD.json
+     * Filename format: health-report-{domain}-YYYY-MM-DD.json
      *
      * This method terminates the application after sending the response.
      *
@@ -62,7 +62,7 @@ class JsonView extends BaseJsonView
         $checkFilter = $input->get('export_checks', [], 'array');
 
         header('Content-Type: application/json; charset=utf-8');
-        header('Content-Disposition: attachment; filename="health-report-' . date('Y-m-d') . '.json"');
+        header('Content-Disposition: attachment; filename="' . $model::getExportFilename('json') . '"');
 
         $isFiltered = $input->getInt('export_filtered', 0) === 1;
 

--- a/healthchecker/component/src/View/Report/MarkdownView.php
+++ b/healthchecker/component/src/View/Report/MarkdownView.php
@@ -42,7 +42,7 @@ class MarkdownView extends BaseHtmlView
      * Executes all health checks, gathers metadata, and renders a Markdown document.
      * The document is sent as a downloadable .md file with appropriate headers.
      *
-     * Filename format: health-report-YYYY-MM-DD.md
+     * Filename format: health-report-{domain}-YYYY-MM-DD.md
      *
      * This method terminates the application after sending the response.
      *
@@ -92,7 +92,7 @@ class MarkdownView extends BaseHtmlView
         $totalCount = $exportCounts['total'];
 
         header('Content-Type: text/markdown; charset=utf-8');
-        header('Content-Disposition: attachment; filename="health-report-' . date('Y-m-d') . '.md"');
+        header('Content-Disposition: attachment; filename="' . $model::getExportFilename('md') . '"');
 
         echo $this->renderMarkdownReport(
             $results,


### PR DESCRIPTION
## Summary

- Export filenames now contain the site's domain, making it straightforward to identify which site a report belongs to when multiple exports land in the same folder
- Adds `ReportModel::getExportFilename()` that extracts the domain from `Uri::root()`, sanitizes it, and builds the filename
- All three export formats (JSON, HTML, Markdown) use this shared method

**Before:** `health-report-2026-02-28.json`
**After:** `health-report-example-com-2026-02-28.json`

Closes #71

## Test plan

- [x] Export in each format (JSON, HTML, Markdown) and confirm the filename includes the site domain
- [x] Verify `composer check` passes (ECS, Rector, PHPStan Level 8, PHPUnit)