### PR TITLE
Add Discover check for uninstalled filesystem extensions (#78)

### DIFF
--- a/healthchecker/component/language/en-GB/com_healthchecker.ini
+++ b/healthchecker/component/language/en-GB/com_healthchecker.ini
@@ -197,6 +197,7 @@ COM_HEALTHCHECKER_CHECK_EXTENSIONS_JOOMLA_CORE_VERSION_TITLE="Joomla Version"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_JOOMLA_UPDATE_CHANNEL_TITLE="Joomla Update Channel"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_JOOMLA_UPDATE_STABILITY_TITLE="Joomla Update Minimum Stability"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISABLED_EXTENSIONS_TITLE="Disabled Extensions"
+COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISCOVER_TITLE="Discovered Extensions"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_UPDATE_SITES_TITLE="Update Sites"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_MISSING_UPDATES_TITLE="Available Updates"
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_LANGUAGE_PACKS_TITLE="Language Packs"
@@ -750,6 +751,10 @@ COM_HEALTHCHECKER_CHECK_EXTENSIONS_UPDATE_SITES_WARNING="%d update site(s) disab
 ; extensions.disabled_extensions
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISABLED_EXTENSIONS_GOOD="%d extension(s) disabled."
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISABLED_EXTENSIONS_WARNING="%d extensions are disabled. Consider uninstalling unused extensions."
+
+; extensions.discover
+COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISCOVER_GOOD="No undiscovered extensions found. All extensions on the filesystem are properly installed."
+COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISCOVER_WARNING="%d extension(s) found on the filesystem that are not installed. These should be installed or removed via the Discover page."
 
 ; extensions.cache_plugin
 COM_HEALTHCHECKER_CHECK_EXTENSIONS_CACHE_PLUGIN_GOOD="System caching is enabled. Page cache plugin is available for additional performance gains."

--- a/healthchecker/plugins/core/src/Checks/Extensions/DiscoverCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Extensions/DiscoverCheck.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright   (C) 2026 https://mySites.guru + Phil E. Taylor <phil@phil-taylor.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @link        https://github.com/mySites-guru/HealthCheckerForJoomla
+ */
+
+/**
+ * Discovered Extensions Health Check
+ *
+ * This check runs a fresh Joomla Discover scan and reports any extensions
+ * found on the filesystem that have not been formally installed.
+ *
+ * WHY THIS CHECK IS IMPORTANT:
+ * Extensions sitting on the filesystem without being installed can pose
+ * security risks. They may contain vulnerabilities that cannot be patched
+ * through Joomla's update system since they are not registered. They also
+ * indicate incomplete installations or leftover files from manual deployments
+ * that should be cleaned up.
+ *
+ * RESULT MEANINGS:
+ *
+ * GOOD: No undiscovered extensions found. All extensions on the filesystem
+ * are properly installed.
+ *
+ * WARNING: One or more extensions were found on the filesystem that are not
+ * installed. Visit the Discover page to install or remove them.
+ *
+ * CRITICAL: This check does not return CRITICAL status.
+ */
+
+namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
+
+\defined('_JEXEC') || die;
+
+final class DiscoverCheck extends AbstractHealthCheck
+{
+    public function getSlug(): string
+    {
+        return 'extensions.discover';
+    }
+
+    public function getCategory(): string
+    {
+        return 'extensions';
+    }
+
+    public function getDocsUrl(?HealthStatus $healthStatus = null): string
+    {
+        return 'https://github.com/mySites-guru/HealthCheckerForJoomla/blob/main/healthchecker/plugins/core/src/Checks/Extensions/DiscoverCheck.php';
+    }
+
+    public function getActionUrl(?HealthStatus $healthStatus = null): ?string
+    {
+        if ($healthStatus === HealthStatus::Warning) {
+            return '/administrator/index.php?option=com_installer&view=discover';
+        }
+
+        return null;
+    }
+
+    /**
+     * Performs the discovered extensions health check.
+     *
+     * Triggers a fresh Joomla Discover scan via the com_installer MVC factory
+     * to ensure results are current, then queries the database for extensions
+     * with state = -1 (discovered but not installed).
+     *
+     * If the Discover scan cannot be triggered (e.g. com_installer unavailable),
+     * the check falls back to reading existing state from the database.
+     *
+     * @return HealthCheckResult WARNING if undiscovered extensions exist, GOOD otherwise
+     */
+    protected function performCheck(): HealthCheckResult
+    {
+        $database = $this->requireDatabase();
+
+        $this->runDiscoverScan();
+
+        $query = $database->getQuery(true)
+            ->select('COUNT(*)')
+            ->from($database->quoteName('#__extensions'))
+            ->where($database->quoteName('state') . ' = -1');
+
+        $discoveredCount = (int) $database->setQuery($query)
+            ->loadResult();
+
+        if ($discoveredCount > 0) {
+            return $this->warning(
+                Text::sprintf('COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISCOVER_WARNING', $discoveredCount),
+            );
+        }
+
+        return $this->good(Text::_('COM_HEALTHCHECKER_CHECK_EXTENSIONS_DISCOVER_GOOD'));
+    }
+
+    /**
+     * Trigger a fresh Discover scan via Joomla's com_installer.
+     *
+     * This purges stale discovered entries and re-scans the filesystem
+     * for extensions that exist but are not installed. Silently fails
+     * if com_installer is unavailable.
+     */
+    private function runDiscoverScan(): void
+    {
+        try {
+            $component = Factory::getApplication()->bootComponent('com_installer');
+            $model = $component->getMVCFactory()
+                ->createModel('Discover', 'Administrator', [
+                    'ignore_request' => true,
+                ]);
+            $model->discover();
+        } catch (\Throwable) {
+            // Fall back to reading existing state from the database
+        }
+    }
+}

--- a/tests/Unit/Plugin/Core/Checks/Extensions/DiscoverCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Extensions/DiscoverCheckTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright   (C) 2026 https://mySites.guru + Phil E. Taylor <phil@phil-taylor.com>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @link        https://github.com/mySites-guru/HealthCheckerForJoomla
+ */
+
+namespace HealthChecker\Tests\Unit\Plugin\Core\Checks\Extensions;
+
+use HealthChecker\Tests\Utilities\MockDatabaseFactory;
+use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Factory;
+use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
+use MySitesGuru\HealthChecker\Plugin\Core\Checks\Extensions\DiscoverCheck;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DiscoverCheck::class)]
+class DiscoverCheckTest extends TestCase
+{
+    private DiscoverCheck $discoverCheck;
+
+    private CMSApplication $cmsApplication;
+
+    protected function setUp(): void
+    {
+        $this->cmsApplication = new CMSApplication();
+        $this->cmsApplication->setComponent('com_installer', $this->createInstallerComponent());
+        Factory::setApplication($this->cmsApplication);
+
+        $this->discoverCheck = new DiscoverCheck();
+    }
+
+    protected function tearDown(): void
+    {
+        Factory::setApplication(null);
+    }
+
+    public function testGetSlugReturnsCorrectValue(): void
+    {
+        $this->assertSame('extensions.discover', $this->discoverCheck->getSlug());
+    }
+
+    public function testGetCategoryReturnsExtensions(): void
+    {
+        $this->assertSame('extensions', $this->discoverCheck->getCategory());
+    }
+
+    public function testGetProviderReturnsCore(): void
+    {
+        $this->assertSame('core', $this->discoverCheck->getProvider());
+    }
+
+    public function testGetTitleReturnsString(): void
+    {
+        $title = $this->discoverCheck->getTitle();
+
+        $this->assertIsString($title);
+        $this->assertNotEmpty($title);
+    }
+
+    public function testRunWithoutDatabaseReturnsWarning(): void
+    {
+        $healthCheckResult = $this->discoverCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+    }
+
+    public function testRunWithZeroDiscoveredExtensionsReturnsGood(): void
+    {
+        $database = MockDatabaseFactory::createWithResult(0);
+        $this->discoverCheck->setDatabase($database);
+
+        $healthCheckResult = $this->discoverCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString('DISCOVER_GOOD', $healthCheckResult->description);
+    }
+
+    public function testRunWithDiscoveredExtensionsReturnsWarning(): void
+    {
+        $database = MockDatabaseFactory::createWithResult(3);
+        $this->discoverCheck->setDatabase($database);
+
+        $healthCheckResult = $this->discoverCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString('DISCOVER_WARNING', $healthCheckResult->description);
+    }
+
+    public function testRunWithOneDiscoveredExtensionReturnsWarning(): void
+    {
+        $database = MockDatabaseFactory::createWithResult(1);
+        $this->discoverCheck->setDatabase($database);
+
+        $healthCheckResult = $this->discoverCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+    }
+
+    public function testRunWithFailedDiscoverScanStillWorks(): void
+    {
+        $this->cmsApplication->setComponent('com_installer', null);
+        $database = MockDatabaseFactory::createWithResult(0);
+        $this->discoverCheck->setDatabase($database);
+
+        $healthCheckResult = $this->discoverCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
+    public function testGetActionUrlReturnsDiscoverPageOnWarning(): void
+    {
+        $this->assertSame(
+            '/administrator/index.php?option=com_installer&view=discover',
+            $this->discoverCheck->getActionUrl(HealthStatus::Warning),
+        );
+    }
+
+    public function testGetActionUrlReturnsNullOnGood(): void
+    {
+        $this->assertNull($this->discoverCheck->getActionUrl(HealthStatus::Good));
+    }
+
+    public function testGetDocsUrlReturnsString(): void
+    {
+        $this->assertIsString($this->discoverCheck->getDocsUrl());
+        $this->assertNotEmpty($this->discoverCheck->getDocsUrl());
+    }
+
+    /**
+     * Create a mock com_installer component with a discover model.
+     */
+    private function createInstallerComponent(): object
+    {
+        return new class {
+            public function getMVCFactory(): object
+            {
+                return new class {
+                    public function createModel(string $name, string $prefix = '', array $config = []): object
+                    {
+                        return new class {
+                            public function discover(): int
+                            {
+                                return 0;
+                            }
+                        };
+                    }
+                };
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- New `extensions.discover` health check that finds extensions on the filesystem that aren't installed in Joomla
- Runs a fresh Discover scan via `com_installer`'s MVC factory before reading results
- Falls back to existing DB state if the scan can't run

## How it works
1. Calls `DiscoverModel::discover()` which purges stale entries and re-scans the filesystem for unregistered extension manifests
2. Queries `#__extensions WHERE state = -1` for the count
3. Returns **Good** if zero, **Warning** if 1+ with a link to the Discover page

## Test plan
- [x] 12 unit tests covering good/warning/no-db/failed-scan scenarios
- [x] `composer check` passes (ECS, Rector, PHPStan Level 8, PHPUnit)
- [x] Manual test in Docker container