### PR TITLE
Update es-ES translations to v3.8.2

### DIFF
--- a/healthchecker/component/language/es-ES/com_healthchecker.ini
+++ b/healthchecker/component/language/es-ES/com_healthchecker.ini
@@ -1,6 +1,7 @@
 ; Health Checker for Joomla
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; License GNU General Public License version 2 or later; see LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 COM_HEALTHCHECKER="Comprobador de estado"
 COM_HEALTHCHECKER_REPORT="Informe de estado"
@@ -998,4 +999,3 @@ COM_HEALTHCHECKER_CHECK_CONTENT_CATEGORY_DEPTH_WARNING="%d categoría(s) anidada
 ; TrashedContentCheck (content.trashed_content)
 COM_HEALTHCHECKER_CHECK_CONTENT_TRASHED_CONTENT_GOOD="%d artículo(s) en la papelera."
 COM_HEALTHCHECKER_CHECK_CONTENT_TRASHED_CONTENT_WARNING="%d artículos en la papelera. Considere vaciar la papelera para limpiar la base de datos."
-

--- a/healthchecker/component/language/es-ES/com_healthchecker.sys.ini
+++ b/healthchecker/component/language/es-ES/com_healthchecker.sys.ini
@@ -1,6 +1,7 @@
 ; Comprobador de estado para Joomla!
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 COM_HEALTHCHECKER="Comprobador de estado"
 COM_HEALTHCHECKER_XML_DESCRIPTION="Una extensión integral de comprobación de estado para Joomla! con más de 130 verificaciones en más de 8 categorías."

--- a/healthchecker/module/language/es-ES/mod_healthchecker.ini
+++ b/healthchecker/module/language/es-ES/mod_healthchecker.ini
@@ -1,6 +1,7 @@
 ; Módulo del panel de Comprobador de estado - Archivo de idioma español (es-ES)
 ; Copyright (C) 2026 mySites.guru / Phil E. Taylor
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 MOD_HEALTHCHECKER="Comprobador de estado"
 MOD_HEALTHCHECKER_XML_DESCRIPTION="Muestra un resumen de las comprobaciones de estado del sitio en el panel de administración."
@@ -28,4 +29,3 @@ MOD_HEALTHCHECKER_CACHE_NOTE="<strong>Nota:</strong> El uso de caché requiere q
 MOD_HEALTHCHECKER_REFRESH_CACHE="Actualizar resultados"
 
 MOD_HEALTHCHECKER_NO_CHECKS="No se encontraron comprobaciones de estado. Asegúrese de que el plugin Health Checker esté habilitado."
-

--- a/healthchecker/module/language/es-ES/mod_healthchecker.sys.ini
+++ b/healthchecker/module/language/es-ES/mod_healthchecker.sys.ini
@@ -1,7 +1,7 @@
 ; Módulo del panel de Comprobador de estado - Archivo de idioma del sistema
 ; Copyright (C) 2026 mySites.guru / Phil E. Taylor
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 MOD_HEALTHCHECKER="Comprobador de estado"
 MOD_HEALTHCHECKER_XML_DESCRIPTION="Muestra un resumen de las comprobaciones de estado del sitio en el panel de administración."
-

--- a/healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.ini
+++ b/healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.ini
@@ -1,6 +1,7 @@
 ; Plugin Health Checker Akeeba Admin Tools
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_AKEEBAADMINTOOLS="Health Checker - Akeeba Admin Tools"
 PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_XML_DESCRIPTION="Agrega comprobaciones de estado de seguridad de Akeeba Admin Tools a Health Checker para Joomla!"
@@ -111,4 +112,3 @@ PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_AKEEBA_ADMINTOOLS_XSS_BLOCKS_GOOD="%s i
 
 ; Descripciones de comprobaciones - Acceso de administración
 PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_CHECK_AKEEBA_ADMINTOOLS_ADMIN_ACCESS_GOOD="%s intentos de acceso al directorio de administración en los últimos 7 días."
-

--- a/healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.sys.ini
+++ b/healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.sys.ini
@@ -1,3 +1,4 @@
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
+
 PLG_HEALTHCHECKER_AKEEBAADMINTOOLS="Health Checker - Akeeba Admin Tools"
 PLG_HEALTHCHECKER_AKEEBAADMINTOOLS_XML_DESCRIPTION="Agrega comprobaciones de estado de seguridad de Akeeba Admin Tools a Health Checker para Joomla!"
-

--- a/healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.ini
+++ b/healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.ini
@@ -1,6 +1,7 @@
 ; Plugin Health Checker Akeeba Backup
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_AKEEBABACKUP="Health Checker - Akeeba Backup"
 PLG_HEALTHCHECKER_AKEEBABACKUP_XML_DESCRIPTION="Agrega comprobaciones de estado de Akeeba Backup a Health Checker para Joomla!"
@@ -92,4 +93,3 @@ PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_AKEEBA_BACKUP_FAILED_BACKUPS_WARNING="%s co
 PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_AKEEBA_BACKUP_FREQUENCY_GOOD="%s copia(s) de seguridad exitosa(s) en los últimos 30 días."
 PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_AKEEBA_BACKUP_FREQUENCY_WARNING="Solo %s copia(s) de seguridad exitosa(s) en los últimos 30 días. Considere programar copias de seguridad semanales."
 PLG_HEALTHCHECKER_AKEEBABACKUP_CHECK_AKEEBA_BACKUP_FREQUENCY_CRITICAL="No hubo copias de seguridad exitosas en los últimos 30 días. Programe copias de seguridad periódicas de inmediato."
-

--- a/healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.sys.ini
+++ b/healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.sys.ini
@@ -1,3 +1,4 @@
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
+
 PLG_HEALTHCHECKER_AKEEBABACKUP="Health Checker - Akeeba Backup"
 PLG_HEALTHCHECKER_AKEEBABACKUP_XML_DESCRIPTION="Agrega comprobaciones de estado de Akeeba Backup a Health Checker para Joomla!"
-

--- a/healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.ini
+++ b/healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.ini
@@ -1,6 +1,7 @@
 ; Health Checker Core Plugin
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; License GNU General Public License version 2 or later; see LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_CORE="Health Checker - Comprobaciones principales"
 PLG_HEALTHCHECKER_CORE_XML_DESCRIPTION="Proporciona las comprobaciones de estado principales para Health Checker para Joomla!"
@@ -186,4 +187,3 @@ PLG_HEALTHCHECKER_CORE_CHECK_USERS_USER_FIELDS_TITLE="Campos de usuario"
 PLG_HEALTHCHECKER_CORE_CHECK_USERS_USER_GROUPS_TITLE="Grupos de usuarios"
 PLG_HEALTHCHECKER_CORE_CHECK_USERS_USER_NOTES_TITLE="Notas de usuario"
 PLG_HEALTHCHECKER_CORE_CHECK_USERS_USER_REGISTRATION_TITLE="Registro de usuarios"
-

--- a/healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.sys.ini
+++ b/healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.sys.ini
@@ -1,7 +1,7 @@
 ; Plugin principal de Health Checker
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_CORE="Health Checker - Comprobaciones principales"
 PLG_HEALTHCHECKER_CORE_XML_DESCRIPTION="Proporciona más de 130 comprobaciones de estado principales para Health Checker para Joomla!"
-

--- a/healthchecker/plugins/example/language/es-ES/plg_healthchecker_example.ini
+++ b/healthchecker/plugins/example/language/es-ES/plg_healthchecker_example.ini
@@ -1,6 +1,7 @@
 ; Plugin de ejemplo de Health Checker
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_EXAMPLE="Health Checker - Ejemplo"
 PLG_HEALTHCHECKER_EXAMPLE_XML_DESCRIPTION="Plugin de ejemplo que demuestra cómo ampliar Health Checker con comprobaciones de estado personalizadas."
@@ -20,4 +21,3 @@ PLG_HEALTHCHECKER_EXAMPLE_CHECK_EXAMPLE_CUSTOM_CONFIG_WARNING="<p><strong>[COMPR
 PLG_HEALTHCHECKER_EXAMPLE_CHECK_EXAMPLE_THIRDPARTY_SERVICE_GOOD="[COMPROBACIÓN DE EJEMPLO] El servicio API de Joomla! es accesible y responde con normalidad. Para ocultar esto, deshabilite el plugin &quot;Health Checker - Example Provider&quot; en Extensiones → Plugins."
 PLG_HEALTHCHECKER_EXAMPLE_CHECK_EXAMPLE_THIRDPARTY_SERVICE_WARNING="[COMPROBACIÓN DE EJEMPLO] El servicio API de Joomla! es accesible, pero responde lentamente. Para ocultar esto, deshabilite el plugin &quot;Health Checker - Example Provider&quot; en Extensiones → Plugins."
 PLG_HEALTHCHECKER_EXAMPLE_CHECK_EXAMPLE_THIRDPARTY_SERVICE_CRITICAL="[COMPROBACIÓN DE EJEMPLO] No se puede acceder al servicio API de Joomla! Revise la conexión a Internet o la configuración del firewall. Para ocultar esto, deshabilite el plugin &quot;Health Checker - Example Provider&quot; en Extensiones → Plugins."
-

--- a/healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.ini
+++ b/healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.ini
@@ -1,6 +1,7 @@
 ; Plugin Health Checker mySites.guru
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_MYSITESGURU="Health Checker - mySites.guru"
 PLG_HEALTHCHECKER_MYSITESGURU_XML_DESCRIPTION="Comprueba si este sitio está conectado al panel de monitoreo de mySites.guru. Proporciona monitoreo de estado automatizado 24/7, seguimiento de disponibilidad y alertas instantáneas para sus sitios Joomla!"
@@ -32,4 +33,3 @@ PLG_HEALTHCHECKER_MYSITESGURU_EXPORT_NEVER="No exportar nunca"
 ; Descripciones de comprobaciones
 PLG_HEALTHCHECKER_MYSITESGURU_CHECK_MYSITESGURU_CONNECTION_GOOD="Este sitio está conectado al monitoreo de mySites.guru. Sus comprobaciones de estado se ejecutan automáticamente 24/7 con alertas instantáneas cuando surgen problemas."
 PLG_HEALTHCHECKER_MYSITESGURU_CHECK_MYSITESGURU_CONNECTION_WARNING="Este sitio no está conectado a mySites.guru. Monitoree sitios Joomla! ilimitados desde un panel con comprobaciones de estado automatizadas, monitoreo de disponibilidad y alertas instantáneas. Más información en https://mysites.guru"
-

--- a/healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.sys.ini
+++ b/healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.sys.ini
@@ -1,7 +1,7 @@
 ; Plugin Health Checker mySites.guru - Cadenas del sistema
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; Licencia GNU General Public License versión 2 o posterior; consulte LICENSE.txt
+; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 PLG_HEALTHCHECKER_MYSITESGURU="Health Checker - mySites.guru"
 PLG_HEALTHCHECKER_MYSITESGURU_XML_DESCRIPTION="Comprueba si este sitio está conectado al panel de monitoreo de mySites.guru. Proporciona monitoreo de estado automatizado 24/7, seguimiento de disponibilidad y alertas instantáneas para sus sitios Joomla!"
-


### PR DESCRIPTION
Updated all Spanish (es-ES) translation files to v3.8.2.

Files updated:
- healthchecker/component/language/es-ES/com_healthchecker.ini
- healthchecker/component/language/es-ES/com_healthchecker.sys.ini
- healthchecker/modules/mod_healthchecker/language/es-ES/mod_healthchecker.ini
- healthchecker/modules/mod_healthchecker/language/es-ES/mod_healthchecker.sys.ini
- healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.ini
- healthchecker/plugins/core/language/es-ES/plg_healthchecker_core.sys.ini
- healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.ini
- healthchecker/plugins/akeebaadmintools/language/es-ES/plg_healthchecker_akeebaadmintools.sys.ini
- healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.ini
- healthchecker/plugins/akeebabackup/language/es-ES/plg_healthchecker_akeebabackup.sys.ini
- healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.ini
- healthchecker/plugins/mysitesguru/language/es-ES/plg_healthchecker_mysitesguru.sys.ini
- healthchecker/plugins/example/language/es-ES/plg_healthchecker_example.ini