### PR TITLE
Fix Twitter Card check missing tags using property attribute (#101)

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
@@ -196,27 +196,31 @@ final class TwitterCardsCheck extends AbstractHealthCheck
     {
         $tags = [];
 
-        // Match Twitter meta tags: <meta name="twitter:*" content="...">
-        if (preg_match_all(
-            '/<meta\s+[^>]*name=["\']?(twitter:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[1]] = $match[2];
+        // Match Twitter meta tags with either name or property attribute:
+        // <meta name="twitter:*" content="..."> or <meta property="twitter:*" content="...">
+        // Some themes/extensions use "property" instead of "name" for Twitter tags.
+        foreach (['name', 'property'] as $attribute) {
+            if (preg_match_all(
+                '/<meta\s+[^>]*' . $attribute . '=["\']?(twitter:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[1]] ??= $match[2];
+                }
             }
-        }
 
-        // Also check for reverse order: content before name
-        if (preg_match_all(
-            '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*name=["\']?(twitter:[^"\'>\s]+)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[2]] = $match[1];
+            // Also check for reverse order: content before name/property
+            if (preg_match_all(
+                '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*' . $attribute . '=["\']?(twitter:[^"\'>\s]+)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[2]] ??= $match[1];
+                }
             }
         }
 

--- a/tests/Unit/Plugin/Core/Checks/Seo/TwitterCardsCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Seo/TwitterCardsCheckTest.php
@@ -227,6 +227,53 @@ HTML;
         $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
     }
 
+    public function testDetectsPropertyAttributeForTwitterTags(): void
+    {
+        // Some themes use property= instead of name= for Twitter meta tags
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:title" content="My Site Title">
+    <meta property="twitter:description" content="My site description">
+    <meta property="twitter:image" content="https://example.com/image.jpg">
+</head>
+<body></body>
+</html>
+HTML;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $html);
+        $this->twitterCardsCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->twitterCardsCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
+    public function testDetectsContentBeforePropertyOrderForTwitterTags(): void
+    {
+        // Reversed attribute order with property instead of name
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta content="summary_large_image" property="twitter:card">
+    <meta content="My Site Title" property="twitter:title">
+    <meta content="My site description" property="twitter:description">
+</head>
+<body></body>
+</html>
+HTML;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $html);
+        $this->twitterCardsCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->twitterCardsCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
     public function testSuggestsImageWhenMissing(): void
     {
         $html = <<<'HTML'


### PR DESCRIPTION
## Summary

Fixes #101

- The Twitter Card meta tag check only matched `<meta name="twitter:*">` but some Joomla templates and extensions output `<meta property="twitter:*">` instead. Both formats are valid and widely used in the wild.
- Updated `findTwitterTags()` to match both `name` and `property` attributes, with `name` taking precedence when both exist for the same tag.

Thanks to @nzrunner for reporting this.

## Test plan

- [ ] New tests verify `property=` attribute detection (both normal and reversed attribute order)
- [ ] All 2665 existing tests pass
- [ ] ECS, Rector, and PHPStan checks pass