### PR TITLE
Fix Media Manager Thumbnails check reporting wrong status (#100)

### DIFF
--- a/healthchecker/component/language/en-GB/com_healthchecker.ini
+++ b/healthchecker/component/language/en-GB/com_healthchecker.ini
@@ -876,8 +876,9 @@ COM_HEALTHCHECKER_CHECK_PERFORMANCE_SMART_SEARCH_INDEX_GOOD_2="Smart Search inde
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING="Filesystem - Local plugin not found. This core plugin is required for the Media Manager."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_2="Filesystem - Local plugin is disabled. Enable it for the Media Manager to function."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_3="Unable to read Filesystem - Local plugin configuration."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="Media Manager thumbnail generation is disabled. Enable it in the Filesystem - Local plugin settings to improve browsing performance."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Media Manager thumbnails are enabled (%dpx). Browsing large media libraries will be faster."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="No directories configured in the Filesystem - Local plugin. Add at least one directory for the Media Manager to function."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_5="Thumbnail generation is disabled for: %s. Enable it in the Filesystem - Local plugin settings to improve browsing performance."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Thumbnails are enabled for all %d configured directories. Browsing large media libraries will be faster."
 ; SEO category - Alt Text Check (seo.alt_text)
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_GOOD="No images with missing alt text detected in published articles."
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_WARNING="Found approximately %d images without alt text across %d articles. Add descriptive alt text for accessibility and SEO."

--- a/healthchecker/component/language/es-ES/com_healthchecker.ini
+++ b/healthchecker/component/language/es-ES/com_healthchecker.ini
@@ -877,8 +877,9 @@ COM_HEALTHCHECKER_CHECK_PERFORMANCE_SMART_SEARCH_INDEX_GOOD_2="El índice de Bú
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING="No se encontró el plugin Filesystem - Local. Este plugin principal es obligatorio para el Gestor multimedia."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_2="El plugin Filesystem - Local está deshabilitado. Habilítelo para que el Gestor multimedia funcione."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_3="No se pudo leer la configuración del plugin Filesystem - Local."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="La generación de miniaturas del Gestor multimedia está deshabilitada. Habilítela en la configuración del plugin Filesystem - Local para mejorar el rendimiento de navegación."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Las miniaturas del Gestor multimedia están habilitadas (%dpx). La navegación en bibliotecas multimedia grandes será más rápida."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="No hay directorios configurados en el plugin Filesystem - Local. Añada al menos un directorio para que el Gestor multimedia funcione."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_5="La generación de miniaturas está deshabilitada para: %s. Habilítela en la configuración del plugin Filesystem - Local para mejorar el rendimiento de navegación."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Las miniaturas están habilitadas para los %d directorios configurados. La navegación en bibliotecas multimedia grandes será más rápida."
 ; SEO category - Alt Text Check (seo.alt_text)
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_GOOD="No se detectaron imágenes sin texto alternativo en artículos publicados."
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_WARNING="Se encontraron aproximadamente %d imágenes sin texto alternativo en %d artículos. Agregue texto alternativo descriptivo para accesibilidad y SEO."

--- a/healthchecker/component/language/ru-RU/com_healthchecker.ini
+++ b/healthchecker/component/language/ru-RU/com_healthchecker.ini
@@ -863,8 +863,9 @@ COM_HEALTHCHECKER_CHECK_PERFORMANCE_SMART_SEARCH_INDEX_GOOD_2="Индекс Smar
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING="Плагин «Файловая система - Локальный» не найден. Этот основной плагин требуется для медиа-менеджера."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_2="Плагин «Файловая система - Локальный» отключен. Включите его для работы медиа-менеджера."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_3="Не удалось прочитать конфигурацию плагина «Файловая система - Локальный»."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="Генерация миниатюр медиа-менеджера отключена. Включите ее в настройках плагина «Файловая система - Локальный» для повышения производительности просмотра."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Миниатюры медиа-менеджера включены (%dpx). Просмотр больших медиатек будет быстрее."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="В плагине «Файловая система - Локальный» не настроены директории. Добавьте хотя бы одну директорию для работы медиа-менеджера."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_5="Генерация миниатюр отключена для: %s. Включите ее в настройках плагина «Файловая система - Локальный» для повышения производительности просмотра."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Миниатюры включены для всех %d настроенных директорий. Просмотр больших медиатек будет быстрее."
 ; SEO категория - Проверка Alt Text (seo.alt_text)
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_GOOD="Не обнаружено изображений с отсутствующим альтернативным текстом в опубликованных материалах."
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_WARNING="Обнаружено приблизительно %d изображений без альтернативного текста в %d материалах. Добавьте описательный alt-текст для доступности и SEO."

--- a/healthchecker/plugins/core/src/Checks/Performance/MediaManagerThumbnailsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Performance/MediaManagerThumbnailsCheck.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  * Media Manager Thumbnails Health Check
  *
  * This check verifies whether the Filesystem - Local plugin is configured to
- * generate thumbnails for the Media Manager, improving performance when browsing
- * large media libraries.
+ * generate thumbnails for each directory in the Media Manager, improving
+ * performance when browsing large media libraries.
  *
  * WHY THIS CHECK IS IMPORTANT:
  * By default, the Joomla Media Manager loads full-size images when browsing,
@@ -23,11 +23,12 @@ declare(strict_types=1);
  *
  * RESULT MEANINGS:
  *
- * GOOD: Thumbnail generation is enabled. The Media Manager will display optimized
- * thumbnails instead of full-size images, providing faster browsing performance.
+ * GOOD: Thumbnail generation is enabled for all configured directories. The Media
+ * Manager will display optimized thumbnails instead of full-size images.
  *
- * WARNING: Thumbnail generation is disabled or the plugin is not properly configured.
- * Enable thumbnail generation in the Filesystem - Local plugin settings to improve
+ * WARNING: Thumbnail generation is disabled for one or more directories, the plugin
+ * is not properly configured, or no directories are configured at all. Enable
+ * thumbnail generation in the Filesystem - Local plugin settings to improve
  * Media Manager performance, especially for sites with many or large images.
  *
  * CRITICAL: This check does not return CRITICAL status.
@@ -109,18 +110,42 @@ final class MediaManagerThumbnailsCheck extends AbstractHealthCheck
             return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_3'));
         }
 
-        // Check if thumbnail generation is enabled
-        // The parameter is 'thumbnail_size' - if set to a value > 0, thumbnails are enabled
-        $thumbnailSize = (int) ($params['thumbnail_size'] ?? 0);
+        // The plugin stores directories as a subform array under 'directories'.
+        // Each entry has 'directory' (folder name) and 'thumbs' (0 or 1).
+        $directories = $params['directories'] ?? [];
 
-        if ($thumbnailSize <= 0) {
+        if (! is_array($directories) || $directories === []) {
             return $this->warning(
                 Text::_('COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4'),
             );
         }
 
+        $disabledDirs = [];
+
+        foreach ($directories as $directory) {
+            if (! is_array($directory)) {
+                continue;
+            }
+
+            $dirName = (string) ($directory['directory'] ?? '');
+            $thumbsEnabled = (int) ($directory['thumbs'] ?? 0);
+
+            if ($dirName !== '' && $thumbsEnabled === 0) {
+                $disabledDirs[] = $dirName;
+            }
+        }
+
+        if ($disabledDirs !== []) {
+            return $this->warning(
+                Text::sprintf(
+                    'COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_5',
+                    implode(', ', $disabledDirs),
+                ),
+            );
+        }
+
         return $this->good(
-            Text::sprintf('COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD', $thumbnailSize),
+            Text::sprintf('COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD', \count($directories)),
         );
     }
 }

--- a/tests/Unit/Plugin/Core/Checks/Performance/MediaManagerThumbnailsCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Performance/MediaManagerThumbnailsCheckTest.php
@@ -76,7 +76,12 @@ class MediaManagerThumbnailsCheckTest extends TestCase
         $plugin = (object) [
             'enabled' => 0,
             'params' => json_encode([
-                'thumbnail_size' => 200,
+                'directories' => [
+                    'directories0' => [
+                        'directory' => 'images',
+                        'thumbs' => 1,
+                    ],
+                ],
             ]),
         ];
         $database = MockDatabaseFactory::createWithObject($plugin);
@@ -91,12 +96,21 @@ class MediaManagerThumbnailsCheckTest extends TestCase
         );
     }
 
-    public function testRunWithThumbnailsEnabledReturnsGood(): void
+    public function testRunWithAllThumbnailsEnabledReturnsGood(): void
     {
         $plugin = (object) [
             'enabled' => 1,
             'params' => json_encode([
-                'thumbnail_size' => 200,
+                'directories' => [
+                    'directories0' => [
+                        'directory' => 'images',
+                        'thumbs' => 1,
+                    ],
+                    'directories1' => [
+                        'directory' => 'files',
+                        'thumbs' => 1,
+                    ],
+                ],
             ]),
         ];
         $database = MockDatabaseFactory::createWithObject($plugin);
@@ -108,12 +122,42 @@ class MediaManagerThumbnailsCheckTest extends TestCase
         $this->assertStringContainsString('MEDIA_MANAGER_THUMBNAILS_GOOD', $healthCheckResult->description);
     }
 
-    public function testRunWithThumbnailsDisabledReturnsWarning(): void
+    public function testRunWithSingleDirectoryThumbnailsEnabledReturnsGood(): void
     {
         $plugin = (object) [
             'enabled' => 1,
             'params' => json_encode([
-                'thumbnail_size' => 0,
+                'directories' => [
+                    'directories0' => [
+                        'directory' => 'images',
+                        'thumbs' => 1,
+                    ],
+                ],
+            ]),
+        ];
+        $database = MockDatabaseFactory::createWithObject($plugin);
+        $this->mediaManagerThumbnailsCheck->setDatabase($database);
+
+        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
+    public function testRunWithAllThumbnailsDisabledReturnsWarning(): void
+    {
+        $plugin = (object) [
+            'enabled' => 1,
+            'params' => json_encode([
+                'directories' => [
+                    'directories0' => [
+                        'directory' => 'images',
+                        'thumbs' => 0,
+                    ],
+                    'directories1' => [
+                        'directory' => 'files',
+                        'thumbs' => 0,
+                    ],
+                ],
             ]),
         ];
         $database = MockDatabaseFactory::createWithObject($plugin);
@@ -126,6 +170,67 @@ class MediaManagerThumbnailsCheckTest extends TestCase
             'media_manager_thumbnails_warning',
             strtolower($healthCheckResult->description),
         );
+    }
+
+    public function testRunWithPartialThumbnailsDisabledReturnsWarning(): void
+    {
+        $plugin = (object) [
+            'enabled' => 1,
+            'params' => json_encode([
+                'directories' => [
+                    'directories0' => [
+                        'directory' => 'images',
+                        'thumbs' => 1,
+                    ],
+                    'directories1' => [
+                        'directory' => 'files',
+                        'thumbs' => 0,
+                    ],
+                ],
+            ]),
+        ];
+        $database = MockDatabaseFactory::createWithObject($plugin);
+        $this->mediaManagerThumbnailsCheck->setDatabase($database);
+
+        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'media_manager_thumbnails_warning',
+            strtolower($healthCheckResult->description),
+        );
+    }
+
+    public function testRunWithEmptyDirectoriesReturnsWarning(): void
+    {
+        $plugin = (object) [
+            'enabled' => 1,
+            'params' => json_encode([
+                'directories' => [],
+            ]),
+        ];
+        $database = MockDatabaseFactory::createWithObject($plugin);
+        $this->mediaManagerThumbnailsCheck->setDatabase($database);
+
+        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+    }
+
+    public function testRunWithMissingDirectoriesKeyReturnsWarning(): void
+    {
+        $plugin = (object) [
+            'enabled' => 1,
+            'params' => json_encode([
+                'other_param' => 'value',
+            ]),
+        ];
+        $database = MockDatabaseFactory::createWithObject($plugin);
+        $this->mediaManagerThumbnailsCheck->setDatabase($database);
+
+        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
     }
 
     public function testRunWithInvalidParamsReturnsWarning(): void
@@ -144,38 +249,6 @@ class MediaManagerThumbnailsCheckTest extends TestCase
             'media_manager_thumbnails_warning',
             strtolower($healthCheckResult->description),
         );
-    }
-
-    public function testRunWithNegativeThumbnailSizeReturnsWarning(): void
-    {
-        $plugin = (object) [
-            'enabled' => 1,
-            'params' => json_encode([
-                'thumbnail_size' => -100,
-            ]),
-        ];
-        $database = MockDatabaseFactory::createWithObject($plugin);
-        $this->mediaManagerThumbnailsCheck->setDatabase($database);
-
-        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
-
-        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
-    }
-
-    public function testRunWithMissingThumbnailSizeParamReturnsWarning(): void
-    {
-        $plugin = (object) [
-            'enabled' => 1,
-            'params' => json_encode([
-                'other_param' => 'value',
-            ]),
-        ];
-        $database = MockDatabaseFactory::createWithObject($plugin);
-        $this->mediaManagerThumbnailsCheck->setDatabase($database);
-
-        $healthCheckResult = $this->mediaManagerThumbnailsCheck->run();
-
-        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
     }
 
     public function testCheckNeverReturnsCritical(): void


### PR DESCRIPTION
## Summary

Fixes #100

- The check was reading a `thumbnail_size` parameter that doesn't exist in Joomla's Filesystem - Local plugin
- The plugin stores directories as a subform array, where each directory has its own `thumbs` toggle (0/1)
- Because the parameter name was wrong, the check always reported thumbnails as disabled no matter what
- Now iterates all configured directories and checks each one's `thumbs` setting
- Reports which specific directories have thumbnails disabled

Thanks to @nzrunner for reporting this.

## Test plan

- [x] Updated tests cover: all enabled, all disabled, partially disabled, empty directories, missing key
- [x] All 2667 existing tests pass
- [x] ECS, Rector, PHPStan all pass