### PR TITLE
Sitemap check: try HTTP when no physical file exists

### DIFF
--- a/healthchecker/component/language/en-GB/com_healthchecker.ini
+++ b/healthchecker/component/language/en-GB/com_healthchecker.ini
@@ -911,7 +911,8 @@ COM_HEALTHCHECKER_CHECK_SEO_SITE_META_DESCRIPTION_WARNING_3="Site meta descripti
 
 ; SEO category - Sitemap Check (seo.sitemap)
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD="sitemap.xml is present in site root."
-COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="sitemap.xml not found in site root. Consider generating a sitemap to help search engines discover your content."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2="Sitemap is served dynamically at /sitemap.xml and contains valid XML structure."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="No sitemap found at /sitemap.xml (checked both on disk and via HTTP). Consider installing a sitemap extension to help search engines discover your content."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2="sitemap.xml exists but could not be read."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3="sitemap.xml exists but appears to be empty. Regenerate your sitemap."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4="sitemap.xml exists but contains invalid XML. Check for syntax errors."

--- a/healthchecker/component/language/es-ES/com_healthchecker.ini
+++ b/healthchecker/component/language/es-ES/com_healthchecker.ini
@@ -912,7 +912,8 @@ COM_HEALTHCHECKER_CHECK_SEO_SITE_META_DESCRIPTION_WARNING_3="La meta description
 
 ; SEO category - Sitemap Check (seo.sitemap)
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD="sitemap.xml está presente en la raíz del sitio."
-COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="No se encontró sitemap.xml en la raíz del sitio. Considere generar un mapa del sitio para ayudar a los motores de búsqueda a descubrir su contenido."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2="El mapa del sitio se sirve dinámicamente en /sitemap.xml y contiene una estructura XML válida."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="No se encontró mapa del sitio en /sitemap.xml (comprobado tanto en disco como por HTTP). Considere instalar una extensión de mapa del sitio para ayudar a los motores de búsqueda a descubrir su contenido."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2="sitemap.xml existe, pero no se pudo leer."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3="sitemap.xml existe, pero parece estar vacío. Regenere el mapa del sitio."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4="sitemap.xml existe, pero contiene XML no válido. Revise los errores de sintaxis."

--- a/healthchecker/component/language/ru-RU/com_healthchecker.ini
+++ b/healthchecker/component/language/ru-RU/com_healthchecker.ini
@@ -898,7 +898,8 @@ COM_HEALTHCHECKER_CHECK_SEO_SITE_META_DESCRIPTION_WARNING_3="Мета-описа
 
 ; SEO категория - Проверка Sitemap (seo.sitemap)
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD="sitemap.xml присутствует в корне сайта."
-COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="sitemap.xml не найден в корне сайта. Рекомендуется создать карту сайта, чтобы помочь поисковым системам находить ваш контент."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2="Карта сайта обслуживается динамически по адресу /sitemap.xml и содержит корректную структуру XML."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="Карта сайта не найдена по адресу /sitemap.xml (проверено на диске и по HTTP). Рекомендуется установить расширение для карты сайта, чтобы помочь поисковым системам находить ваш контент."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2="sitemap.xml существует, но не может быть прочитан."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3="sitemap.xml существует, но, похоже, пуст. Перегенерируйте карту сайта."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4="sitemap.xml существует, но содержит недопустимый XML. Проверьте на наличие синтаксических ошибок."

--- a/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/SitemapCheck.php
@@ -11,7 +11,8 @@ declare(strict_types=1);
 /**
  * XML Sitemap Health Check
  *
- * This check verifies that an XML sitemap exists in the site root and contains
+ * This check verifies that an XML sitemap exists either as a physical file
+ * or served dynamically (e.g. by extensions like PWT Sitemap) and contains
  * valid sitemap structure to help search engines discover all your content.
  *
  * WHY THIS CHECK IS IMPORTANT:
@@ -23,12 +24,11 @@ declare(strict_types=1);
  *
  * RESULT MEANINGS:
  *
- * GOOD: A valid XML sitemap exists at /sitemap.xml containing proper urlset
- * or sitemapindex structure for search engine consumption.
+ * GOOD: A valid XML sitemap exists at /sitemap.xml (either as a physical file
+ * or served dynamically) containing proper urlset or sitemapindex structure.
  *
- * WARNING: Either no sitemap.xml exists, the file is empty, or it doesn't
- * contain valid XML sitemap structure (missing urlset or sitemapindex elements).
- * Install an XML sitemap extension or generate one manually.
+ * WARNING: No sitemap.xml found on disk or via HTTP, the content is empty,
+ * or it doesn't contain valid XML sitemap structure.
  *
  * CRITICAL: This check does not return critical status.
  */
@@ -36,6 +36,7 @@ declare(strict_types=1);
 namespace MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Uri\Uri;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\AbstractHealthCheck;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthCheckResult;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
@@ -44,6 +45,8 @@ use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 
 final class SitemapCheck extends AbstractHealthCheck
 {
+    private const HTTP_TIMEOUT_SECONDS = 10;
+
     /**
      * Get the unique slug identifier for this check.
      *
@@ -72,39 +75,69 @@ final class SitemapCheck extends AbstractHealthCheck
     /**
      * Perform the XML sitemap health check.
      *
-     * Verifies that a valid XML sitemap exists at the standard location
-     * (/sitemap.xml) and contains proper sitemap structure. Validates XML
-     * syntax and checks for required urlset or sitemapindex elements that
-     * search engines need to parse the sitemap correctly.
+     * First checks for a physical sitemap.xml file on disk. If not found,
+     * falls back to fetching /sitemap.xml via HTTP to detect dynamically
+     * generated sitemaps (e.g. PWT Sitemap). Follows redirects automatically
+     * to handle sitemap index redirects.
      *
      * @return HealthCheckResult The check result with status and description
      */
     protected function performCheck(): HealthCheckResult
     {
-        // sitemap.xml must be in site root as per sitemap protocol specification.
-        // Search engines look for it at http://example.com/sitemap.xml
+        // Phase 1: Check for a physical sitemap.xml file on disk.
         $sitemapPath = JPATH_ROOT . '/sitemap.xml';
 
-        if (! file_exists($sitemapPath)) {
+        if (file_exists($sitemapPath)) {
+            $content = @file_get_contents($sitemapPath);
+
+            if ($content === false) {
+                return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2'));
+            }
+
+            return $this->validateSitemapContent($content)
+                ?? $this->good(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD'));
+        }
+
+        // Phase 2: No physical file — try fetching via HTTP for dynamic sitemaps.
+        return $this->checkViaHttp();
+    }
+
+    /**
+     * Fetch /sitemap.xml via HTTP to detect dynamically generated sitemaps.
+     *
+     * Joomla's HTTP client follows redirects automatically, so extensions
+     * that 301 redirect from /sitemap.xml to sub-sitemaps are handled.
+     */
+    private function checkViaHttp(): HealthCheckResult
+    {
+        try {
+            $sitemapUrl = Uri::root() . 'sitemap.xml';
+            $http = $this->getHttpClient();
+            $response = $http->get($sitemapUrl, [], self::HTTP_TIMEOUT_SECONDS);
+
+            if ($response->code !== 200) {
+                return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING'));
+            }
+
+            $content = $response->body;
+
+            return $this->validateSitemapContent($content)
+                ?? $this->good(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2'));
+        } catch (\Throwable) {
+            // Network failure — fall back to the standard "not found" warning.
             return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING'));
         }
+    }
 
-        // Attempt to read sitemap contents. Using @ to suppress warnings
-        // for permission issues, handled by false check below.
-        $content = @file_get_contents($sitemapPath);
-
-        if ($content === false) {
-            return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2'));
-        }
-
-        // Empty sitemaps are useless for search engines and may indicate
-        // a failed generation or corrupted file.
+    /**
+     * Validate sitemap XML content and return a warning result if invalid, or null if valid.
+     */
+    private function validateSitemapContent(string $content): ?HealthCheckResult
+    {
         if (trim($content) === '') {
             return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3'));
         }
 
-        // Validate that the file contains well-formed XML.
-        // Using internal error handling to catch XML parsing errors gracefully.
         libxml_use_internal_errors(true);
         $xml = simplexml_load_string($content);
         libxml_clear_errors();
@@ -113,10 +146,6 @@ final class SitemapCheck extends AbstractHealthCheck
             return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4'));
         }
 
-        // Check for required sitemap protocol elements.
-        // A valid sitemap must have either <urlset> (single sitemap) or
-        // <sitemapindex> (sitemap index pointing to multiple sitemaps).
-        // Without these, search engines won't recognize it as a valid sitemap.
         $hasUrlset = stripos($content, '<urlset') !== false;
         $hasSitemapIndex = stripos($content, '<sitemapindex') !== false;
 
@@ -124,8 +153,6 @@ final class SitemapCheck extends AbstractHealthCheck
             return $this->warning(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_5'));
         }
 
-        // Sitemap exists, is valid XML, and contains required sitemap elements.
-        // Further validation of URLs and structure would require full parsing.
-        return $this->good(Text::_('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD'));
+        return null;
     }
 }

--- a/tests/Unit/Plugin/Core/Checks/Seo/SitemapCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Seo/SitemapCheckTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace HealthChecker\Tests\Unit\Plugin\Core\Checks\Seo;
 
+use HealthChecker\Tests\Utilities\MockHttpFactory;
 use MySitesGuru\HealthChecker\Component\Administrator\Check\HealthStatus;
 use MySitesGuru\HealthChecker\Plugin\Core\Checks\Seo\SitemapCheck;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -69,17 +70,7 @@ class SitemapCheckTest extends TestCase
         $this->assertNotEmpty($title);
     }
 
-    public function testRunReturnsWarningWhenSitemapNotFound(): void
-    {
-        // No sitemap.xml exists
-        $healthCheckResult = $this->sitemapCheck->run();
-
-        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
-        $this->assertStringContainsString(
-            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING',
-            $healthCheckResult->description,
-        );
-    }
+    // ---- Phase 1: Physical file tests (existing behavior) ----
 
     public function testRunReturnsGoodWhenValidUrlsetSitemapExists(): void
     {
@@ -254,5 +245,163 @@ SITEMAP;
 
         // Should handle BOM gracefully
         $this->assertContains($healthCheckResult->healthStatus, [HealthStatus::Good, HealthStatus::Warning]);
+    }
+
+    // ---- Phase 2: HTTP fallback tests (new behavior) ----
+
+    public function testRunReturnsGoodWhenDynamicSitemapServedViaHttp(): void
+    {
+        // No physical file exists — HTTP returns valid sitemap
+        $sitemapXml = <<<'SITEMAP'
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://example.com/</loc>
+    </url>
+</urlset>
+SITEMAP;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $sitemapXml);
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsGoodWhenDynamicSitemapIndexServedViaHttp(): void
+    {
+        // No physical file — HTTP returns a sitemapindex (e.g. PWT Sitemap after redirect)
+        $sitemapXml = <<<'SITEMAP'
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://example.com/sitemap-articles.xml</loc>
+    </sitemap>
+</sitemapindex>
+SITEMAP;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $sitemapXml);
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsWarningWhenHttpReturnsNon200(): void
+    {
+        // No physical file, HTTP returns 404
+        $httpClient = MockHttpFactory::createWithGetResponse(404);
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsWarningWhenHttpReturnsEmptyBody(): void
+    {
+        // No physical file, HTTP returns 200 but empty body
+        $httpClient = MockHttpFactory::createWithGetResponse(200, '');
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsWarningWhenHttpReturnsInvalidXml(): void
+    {
+        // No physical file, HTTP returns 200 but invalid XML
+        $httpClient = MockHttpFactory::createWithGetResponse(200, '<html><body>Not XML</body>');
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsWarningWhenHttpReturnsXmlWithoutSitemapStructure(): void
+    {
+        // No physical file, HTTP returns valid XML but not sitemap structure
+        $xmlContent = '<?xml version="1.0"?><rss><channel><title>Feed</title></channel></rss>';
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $xmlContent);
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_5',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsWarningWhenHttpThrowsException(): void
+    {
+        // No physical file, network failure
+        $httpClient = MockHttpFactory::createThatThrows('Connection timed out');
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Warning, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunPrefersPhysicalFileOverHttp(): void
+    {
+        // Physical file exists AND HTTP client is set — should use file, not HTTP
+        $sitemapContent = '<?xml version="1.0"?><urlset></urlset>';
+        file_put_contents($this->sitemapPath, $sitemapContent);
+
+        // Set HTTP client that would return different content (should not be called)
+        $httpClient = MockHttpFactory::createThatThrows('Should not be called');
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+        // Should use GOOD (file-based), not GOOD_2 (HTTP-based)
+        $this->assertStringContainsString('COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD', $healthCheckResult->description);
+        $this->assertStringNotContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testHttpFallbackNeverReturnsCritical(): void
+    {
+        // Even with HTTP returning invalid content, should only return warning
+        $httpClient = MockHttpFactory::createWithGetResponse(200, 'completely invalid content');
+        $this->sitemapCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->sitemapCheck->run();
+
+        $this->assertNotSame(HealthStatus::Critical, $healthCheckResult->healthStatus);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #102

- The sitemap check only looked for a physical `sitemap.xml` on disk, so extensions like PWT Sitemap that generate sitemaps dynamically through menu routes got flagged as missing
- Now tries an HTTP GET to `/sitemap.xml` when no file is found. Joomla's HTTP client follows redirects on its own, so PWT Sitemap's 301 chain works fine
- The HTTP response gets the same XML validation (urlset/sitemapindex) as the file path
- If the HTTP request fails, the check just returns the normal "no sitemap found" warning

Thanks to @nzrunner for reporting this.

## Test plan

- [x] 9 new tests for the HTTP fallback (valid sitemap, sitemapindex, non-200, empty body, invalid XML, missing structure, network error, file-takes-priority, never-critical)
- [x] All 2677 existing tests pass
- [x] `composer check` passes (ECS, Rector, PHPStan, PHPUnit)