### PR TITLE
Only enable plugins and publish module on fresh install

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -665,23 +665,25 @@ class Pkg_HealthcheckerInstallerScript
     {
         $this->removeObsoleteFiles();
 
-        $this->enablePlugin('healthchecker', 'core');
-        $this->enablePlugin('healthchecker', 'example');
-        $this->enablePlugin('healthchecker', 'mysitesguru');
+        if ($type === 'install') {
+            $this->enablePlugin('healthchecker', 'core');
+            $this->enablePlugin('healthchecker', 'example');
+            $this->enablePlugin('healthchecker', 'mysitesguru');
 
-        if ($this->isExtensionInstalled('component', 'com_akeebabackup')) {
-            $this->enablePlugin('healthchecker', 'akeebabackup');
+            if ($this->isExtensionInstalled('component', 'com_akeebabackup')) {
+                $this->enablePlugin('healthchecker', 'akeebabackup');
+            }
+            if ($this->isExtensionInstalled('component', 'com_admintools')) {
+                $this->enablePlugin('healthchecker', 'akeebaadmintools');
+            }
+
+            $this->publishModule('mod_healthchecker', 'cpanel');
+
+            Factory::getApplication()->enqueueMessage(
+                'Health Checker installed successfully! Access it from Components > Health Checker.',
+                'success'
+            );
         }
-        if ($this->isExtensionInstalled('component', 'com_admintools')) {
-            $this->enablePlugin('healthchecker', 'akeebaadmintools');
-        }
-
-        $this->publishModule('mod_healthchecker', 'cpanel');
-
-        Factory::getApplication()->enqueueMessage(
-            'Health Checker installed successfully! Access it from Components > Health Checker.',
-            'success'
-        );
     }
 
     private function enablePlugin(string $group, string $element): void


### PR DESCRIPTION
## Summary
- The package `script.php` called `enablePlugin()` and `publishModule()` unconditionally in `postflight()`, re-enabling disabled plugins on every update
- Wrapped those calls in a `$type === 'install'` guard so they only fire on fresh installs
- `removeObsoleteFiles()` still runs on both install and update

Thanks [@nzrunner](https://github.com/nzrunner) for reporting this.

## Test plan
- [ ] Fresh install of the package: all plugins should be enabled and module published
- [ ] Update an existing install with some plugins disabled: disabled plugins should stay disabled
- [ ] Verify obsolete file cleanup still runs on update

Fixes #106