### PR TITLE
Accept name= attribute for Open Graph meta tags in SEO checks

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Seo/FacebookOpenGraphCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/FacebookOpenGraphCheck.php
@@ -162,28 +162,31 @@ final class FacebookOpenGraphCheck extends AbstractHealthCheck
     {
         $tags = [];
 
-        // Match Open Graph meta tags: <meta property="og:*" content="...">
-        // Also match fb:* tags
-        if (preg_match_all(
-            '/<meta\s+[^>]*property=["\']?(og:[^"\'>\s]+|fb:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[1]] = $match[2];
+        // Match Open Graph and fb:* meta tags with either property or name attribute.
+        // The OG spec requires "property", but many sites/extensions use "name" instead.
+        // Facebook's scraper accepts both, so we should too.
+        foreach (['property', 'name'] as $attribute) {
+            if (preg_match_all(
+                '/<meta\s+[^>]*' . $attribute . '=["\']?(og:[^"\'>\s]+|fb:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[1]] ??= $match[2];
+                }
             }
-        }
 
-        // Also check for reverse order: content before property
-        if (preg_match_all(
-            '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*property=["\']?(og:[^"\'>\s]+|fb:[^"\'>\s]+)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[2]] = $match[1];
+            // Also check for reverse order: content before property/name
+            if (preg_match_all(
+                '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*' . $attribute . '=["\']?(og:[^"\'>\s]+|fb:[^"\'>\s]+)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[2]] ??= $match[1];
+                }
             }
         }
 

--- a/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Seo/TwitterCardsCheck.php
@@ -238,27 +238,30 @@ final class TwitterCardsCheck extends AbstractHealthCheck
     {
         $tags = [];
 
-        // Match Open Graph meta tags: <meta property="og:*" content="...">
-        if (preg_match_all(
-            '/<meta\s+[^>]*property=["\']?(og:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[1]] = $match[2];
+        // Match Open Graph meta tags with either property or name attribute.
+        // The OG spec requires "property", but many sites/extensions use "name" instead.
+        foreach (['property', 'name'] as $attribute) {
+            if (preg_match_all(
+                '/<meta\s+[^>]*' . $attribute . '=["\']?(og:[^"\'>\s]+)["\']?\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[1]] ??= $match[2];
+                }
             }
-        }
 
-        // Also check for reverse order: content before property
-        if (preg_match_all(
-            '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*property=["\']?(og:[^"\'>\s]+)["\']?[^>]*>/i',
-            $html,
-            $matches,
-            PREG_SET_ORDER,
-        )) {
-            foreach ($matches as $match) {
-                $tags[$match[2]] = $match[1];
+            // Also check for reverse order: content before property/name
+            if (preg_match_all(
+                '/<meta\s+[^>]*content=["\']?([^"\'>\s][^"\']*)["\']?\s+[^>]*' . $attribute . '=["\']?(og:[^"\'>\s]+)["\']?[^>]*>/i',
+                $html,
+                $matches,
+                PREG_SET_ORDER,
+            )) {
+                foreach ($matches as $match) {
+                    $tags[$match[2]] ??= $match[1];
+                }
             }
         }
 

--- a/tests/Unit/Plugin/Core/Checks/Seo/FacebookOpenGraphCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Seo/FacebookOpenGraphCheckTest.php
@@ -205,6 +205,85 @@ HTML;
         $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
     }
 
+    public function testRunReturnsGoodWhenTagsUseNameAttribute(): void
+    {
+        // Some sites/extensions use name= instead of property= for OG tags
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="og:url" content="https://example.com/">
+    <meta name="og:site_name" content="Example Site">
+    <meta name="og:type" content="website">
+    <meta name="og:locale" content="en_GB">
+    <meta name="og:title" content="My Site Title">
+    <meta name="og:description" content="My site description that is over 120 characters long">
+    <meta name="og:image" content="https://example.com/images/header.png">
+    <meta name="fb:app_id" content="9876543210">
+</head>
+<body></body>
+</html>
+HTML;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $html);
+        $this->facebookOpenGraphCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->facebookOpenGraphCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+        $this->assertStringContainsString(
+            'COM_HEALTHCHECKER_CHECK_SEO_FACEBOOK_OPEN_GRAPH_GOOD_APPID',
+            $healthCheckResult->description,
+        );
+    }
+
+    public function testRunReturnsGoodWhenTagsMixNameAndPropertyAttributes(): void
+    {
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta property="og:title" content="My Site Title">
+    <meta name="og:description" content="My site description">
+    <meta property="og:image" content="https://example.com/image.jpg">
+    <meta name="og:url" content="https://example.com/">
+</head>
+<body></body>
+</html>
+HTML;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $html);
+        $this->facebookOpenGraphCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->facebookOpenGraphCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
+    public function testPropertyAttributeTakesPrecedenceOverName(): void
+    {
+        $html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <meta property="og:title" content="Property Title">
+    <meta name="og:title" content="Name Title">
+    <meta property="og:description" content="Property Description">
+    <meta property="og:image" content="https://example.com/image.jpg">
+    <meta property="og:url" content="https://example.com/">
+</head>
+<body></body>
+</html>
+HTML;
+
+        $httpClient = MockHttpFactory::createWithGetResponse(200, $html);
+        $this->facebookOpenGraphCheck->setHttpClient($httpClient);
+
+        $healthCheckResult = $this->facebookOpenGraphCheck->run();
+
+        $this->assertSame(HealthStatus::Good, $healthCheckResult->healthStatus);
+    }
+
     public function testResultMetadata(): void
     {
         $html = '<html><head></head><body></body></html>';


### PR DESCRIPTION
## Summary

- The `findOpenGraphTags()` regex in both `FacebookOpenGraphCheck` and `TwitterCardsCheck` only matched `property="og:..."` but not `name="og:..."`. Many Joomla extensions (and the user's site in #109) output OG tags with the `name` attribute. Facebook's scraper accepts both, so our checks should too.
- Both checks now loop over `['property', 'name']` when matching, with `property` taking precedence via `??=`. This matches the pattern already used in `TwitterCardsCheck::findTwitterTags()`.
- Added 3 test cases: name-only tags, mixed name/property, and property-takes-precedence.

Fixes #109

## Test plan

- [x] All 2685 tests pass
- [x] `composer check` passes (ECS, Rector, PHPStan Level 8, PHPUnit)
- [x] Manual test on a site using `name=` for OG tags