### PR TITLE
Fix es-ES translation errors in com_healthchecker.ini

### DIFF
--- a/healthchecker/component/language/es-ES/com_healthchecker.ini
+++ b/healthchecker/component/language/es-ES/com_healthchecker.ini
@@ -1,7 +1,6 @@
 ; Health Checker for Joomla
 ; (C) 2026 mySites.guru / Phil E. Taylor <phil@phil-taylor.com>
 ; License GNU General Public License version 2 or later; see LICENSE.txt
-; Spanish translation by Andrés Restrepo (https://alamarte.com)
 
 COM_HEALTHCHECKER="Comprobador de estado"
 COM_HEALTHCHECKER_REPORT="Informe de estado"
@@ -877,9 +876,9 @@ COM_HEALTHCHECKER_CHECK_PERFORMANCE_SMART_SEARCH_INDEX_GOOD_2="El índice de Bú
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING="No se encontró el plugin Filesystem - Local. Este plugin principal es obligatorio para el Gestor multimedia."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_2="El plugin Filesystem - Local está deshabilitado. Habilítelo para que el Gestor multimedia funcione."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_3="No se pudo leer la configuración del plugin Filesystem - Local."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="La generación de miniaturas del Gestor multimedia está deshabilitada. Habilítela en la configuración del plugin Filesystem - Local para mejorar el rendimiento de navegación."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_4="No hay directorios configurados en el plugin Filesystem - Local. Añada al menos un directorio para que el Gestor multimedia funcione."
 COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_WARNING_5="La generación de miniaturas está desactivada para: %s. Actívela en la configuración del plugin Filesystem - Local para mejorar el rendimiento de navegación."
-COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Las miniaturas del Gestor multimedia están habilitadas (%dpx). La navegación en bibliotecas multimedia grandes será más rápida."
+COM_HEALTHCHECKER_CHECK_PERFORMANCE_MEDIA_MANAGER_THUMBNAILS_GOOD="Las miniaturas están habilitadas para los %d directorios configurados. La navegación en bibliotecas multimedia grandes será más rápida."
 ; SEO category - Alt Text Check (seo.alt_text)
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_GOOD="No se detectaron imágenes sin texto alternativo en artículos publicados."
 COM_HEALTHCHECKER_CHECK_SEO_ALT_TEXT_WARNING="Se encontraron aproximadamente %d imágenes sin texto alternativo en %d artículos. Agregue texto alternativo descriptivo para accesibilidad y SEO."
@@ -914,7 +913,7 @@ COM_HEALTHCHECKER_CHECK_SEO_SITE_META_DESCRIPTION_WARNING_3="La meta description
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD="sitemap.xml está presente en la raíz del sitio."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_2="El mapa del sitio se sirve dinámicamente en %s y contiene una estructura XML válida."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_GOOD_3="El mapa del sitio se sirve dinámicamente en %s y contiene una estructura XML válida."
-COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="No se encontró sitemap.xml en la raíz del sitio. Considere generar un mapa del sitio para ayudar a los motores de búsqueda a descubrir su contenido."
+COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING="No se encontró ningún mapa del sitio (se comprobaron /sitemap.xml, /xml-sitemap y /xml-sitemap.xml en disco y mediante HTTP). Considere instalar una extensión de mapa del sitio para ayudar a los motores de búsqueda a descubrir su contenido."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_2="sitemap.xml existe, pero no se pudo leer."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_3="sitemap.xml existe, pero parece estar vacío. Regenere el mapa del sitio."
 COM_HEALTHCHECKER_CHECK_SEO_SITEMAP_WARNING_4="sitemap.xml existe, pero contiene XML no válido. Revise los errores de sintaxis."


### PR DESCRIPTION
Fixed three incorrect translations in com_healthchecker.ini:

- MEDIA_MANAGER_THUMBNAILS_WARNING_4: corrected to match English source (missing directories, not thumbnail generation)
- MEDIA_MANAGER_THUMBNAILS_GOOD: fixed %dpx → %d (number of directories, not pixel size)
- SEO_SITEMAP_WARNING: restored full list of checked paths (/sitemap.xml, /xml-sitemap, /xml-sitemap.xml)