### PR TITLE
Discussion: Remove htmlspecialchars() from mySites.guru banner text

### DIFF
--- a/healthchecker/plugins/mysitesguru/src/Extension/MySitesGuruPlugin.php
+++ b/healthchecker/plugins/mysitesguru/src/Extension/MySitesGuruPlugin.php
@@ -204,7 +204,7 @@ final class MySitesGuruPlugin extends CMSPlugin implements SubscriberInterface
         }
 
         $logoUrl = Uri::root() . 'media/plg_healthchecker_mysitesguru/logo.png';
-        $bannerText = htmlspecialchars(Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT'), ENT_QUOTES, 'UTF-8');
+        $bannerText = Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT');
         $bannerLink = htmlspecialchars(Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_LINK'), ENT_QUOTES, 'UTF-8');
         $dismissLabel = htmlspecialchars(Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_DISMISS'), ENT_QUOTES, 'UTF-8');
 
@@ -276,7 +276,7 @@ JS;
     public function onBeforeReportExportDisplay(BeforeReportExportDisplayEvent $beforeReportExportDisplayEvent): void
     {
         $logoUrl = Uri::root() . 'media/plg_healthchecker_mysitesguru/logo.png';
-        $bannerText = htmlspecialchars(Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT'), ENT_QUOTES, 'UTF-8');
+        $bannerText = Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT');
         $bannerLink = htmlspecialchars(Text::_('PLG_HEALTHCHECKER_MYSITESGURU_BANNER_LINK'), ENT_QUOTES, 'UTF-8');
 
         $html = <<<HTML


### PR DESCRIPTION
## Summary

- Removes `htmlspecialchars()` wrapping from `$bannerText` in `MySitesGuruPlugin.php` (part of the alamarte contribution, separated out for discussion)

## Context

This change was in the alamarte contribution zip but left out of #125 because it removes XSS protection on the banner text output.

The `PLG_HEALTHCHECKER_MYSITESGURU_BANNER_TEXT` language string is plain text today, so `htmlspecialchars()` isn't strictly needed. But removing it means that if the language string ever included user-controlled content, or if a translation contained malicious HTML, it would render unescaped.

## Questions

- Is this language string always trusted content we control?
- Should we keep defense-in-depth even for trusted strings?
- Does `htmlspecialchars()` break any intended HTML formatting in the banner text?