### PR TITLE
fix(orphaned-tables): scan library manifests so library-owned tables are not reported as orphaned

### DIFF
--- a/healthchecker/plugins/core/src/Checks/Database/OrphanedTablesCheck.php
+++ b/healthchecker/plugins/core/src/Checks/Database/OrphanedTablesCheck.php
@@ -278,7 +278,8 @@ final class OrphanedTablesCheck extends AbstractHealthCheck
      * Get extension tables by parsing SQL install files.
      *
      * Scans administrator/components/com_[star]/sql/install.mysql[star].sql files
-     * to extract actual table names that extensions create.
+     * to extract actual table names that extensions create, then does the same
+     * for installed libraries.
      *
      * @param string $prefix Table prefix from Joomla configuration
      *
@@ -286,7 +287,7 @@ final class OrphanedTablesCheck extends AbstractHealthCheck
      */
     private function getExtensionTablesFromSql(string $prefix): array
     {
-        $tables = [];
+        $tables = $this->getLibraryTablesFromSql($prefix);
         $componentPath = JPATH_ADMINISTRATOR . '/components';
 
         if (! is_dir($componentPath)) {
@@ -339,56 +340,135 @@ final class OrphanedTablesCheck extends AbstractHealthCheck
      */
     private function getSqlPathsFromManifest(string $componentDir): array
     {
-        $paths = [];
-
         $xmlFiles = glob($componentDir . '/*.xml');
 
         if ($xmlFiles === false || $xmlFiles === []) {
-            return $paths;
+            return [];
         }
 
         foreach ($xmlFiles as $xmlFile) {
-            $xml = @simplexml_load_file($xmlFile);
-
-            if ($xml === false) {
-                continue;
-            }
-
-            // Only process extension manifest files
-            if ($xml->getName() !== 'extension') {
-                continue;
-            }
-
-            // Extract <install><sql><file> paths — bail if any level is missing
-            $sqlNode = $xml->install->sql ?? null;
-
-            if (! $sqlNode instanceof \SimpleXMLElement) {
-                continue;
-            }
-
-            if (! property_exists($sqlNode, 'file')) {
-                continue;
-            }
-
-            if ($sqlNode->file === null) {
-                continue;
-            }
-
-            foreach ($sqlNode->file as $file) {
-                $sqlRelativePath = (string) $file;
-
-                if ($sqlRelativePath === '') {
-                    continue;
-                }
-
-                $paths[] = $componentDir . '/' . $sqlRelativePath;
-            }
+            $paths = $this->getSqlPathsFromManifestFile($xmlFile, $componentDir);
 
             // Only process the first valid manifest
-            break;
+            if ($paths !== null) {
+                return $paths;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Get SQL install file paths declared by a single extension manifest.
+     *
+     * Split out from getSqlPathsFromManifest() because a library keeps its
+     * manifest in administrator/manifests/libraries while its payload lives in
+     * libraries/[name], so the file to parse and the directory to resolve
+     * against are not the same place. For components they are.
+     *
+     * @param string $xmlFile Full path to the manifest XML file
+     * @param string $baseDir Directory the declared SQL paths are relative to
+     *
+     * @return array<string>|null Absolute paths to SQL install files, or null when
+     *                            this file is not an extension manifest declaring SQL
+     */
+    private function getSqlPathsFromManifestFile(string $xmlFile, string $baseDir): ?array
+    {
+        $xml = @simplexml_load_file($xmlFile);
+
+        if ($xml === false) {
+            return null;
+        }
+
+        // Only process extension manifest files
+        if ($xml->getName() !== 'extension') {
+            return null;
+        }
+
+        // Extract <install><sql><file> paths — bail if any level is missing
+        $sqlNode = $xml->install->sql ?? null;
+
+        if (! $sqlNode instanceof \SimpleXMLElement) {
+            return null;
+        }
+
+        if (! property_exists($sqlNode, 'file')) {
+            return null;
+        }
+
+        if ($sqlNode->file === null) {
+            return null;
+        }
+
+        $paths = [];
+
+        foreach ($sqlNode->file as $file) {
+            $sqlRelativePath = (string) $file;
+
+            if ($sqlRelativePath === '') {
+                continue;
+            }
+
+            $paths[] = $baseDir . '/' . $sqlRelativePath;
         }
 
         return $paths;
+    }
+
+    /**
+     * Get library tables by parsing the SQL install files libraries declare.
+     *
+     * Libraries create tables like any other extension — typically a registry
+     * shared by the several extensions that depend on them — but nothing above
+     * this looks at them: the component scan only globs com_[star], and
+     * getExtensionTablesByPrefix() skips every row whose type is not
+     * "component". Their tables were therefore reported as orphaned on every
+     * run, with no way for the site owner to make the warning correct.
+     *
+     * A library's manifest lives in administrator/manifests/libraries/[name].xml
+     * while its files live in libraries/[name], so the manifest is parsed from
+     * one path and its declared SQL resolved against the other.
+     *
+     * @param string $prefix Table prefix from Joomla configuration
+     *
+     * @return array<string> Array of prefixed table names from SQL files
+     */
+    private function getLibraryTablesFromSql(string $prefix): array
+    {
+        $tables = [];
+        $manifestPath = JPATH_ADMINISTRATOR . '/manifests/libraries';
+
+        if (! is_dir($manifestPath)) {
+            return $tables;
+        }
+
+        $manifests = glob($manifestPath . '/*.xml');
+
+        if ($manifests === false) {
+            return $tables;
+        }
+
+        foreach ($manifests as $manifest) {
+            $libraryDir = JPATH_SITE . '/libraries/' . basename($manifest, '.xml');
+
+            $sqlPaths = $this->getSqlPathsFromManifestFile($manifest, $libraryDir) ?? [];
+
+            // Fall back to common hardcoded locations, as the component scan does
+            $sqlPaths = array_unique(array_merge($sqlPaths, [
+                $libraryDir . '/sql/install.mysql.sql',
+                $libraryDir . '/sql/install.mysql.utf8.sql',
+                $libraryDir . '/sql/mysql/install.sql',
+                $libraryDir . '/sql/install.sql',
+            ]));
+
+            foreach ($sqlPaths as $sqlPath) {
+                if (is_file($sqlPath) && is_readable($sqlPath)) {
+                    $tables = array_merge($tables, $this->parseTablesFromSql($sqlPath, $prefix));
+                }
+            }
+        }
+
+        return array_unique($tables);
     }
 
     /**

--- a/tests/Unit/Plugin/Core/Checks/Database/OrphanedTablesCheckTest.php
+++ b/tests/Unit/Plugin/Core/Checks/Database/OrphanedTablesCheckTest.php
@@ -695,6 +695,122 @@ class OrphanedTablesCheckTest extends TestCase
         }
     }
 
+    public function testRunParsesTablesFromLibraryManifestSqlFile(): void
+    {
+        // A library keeps its manifest in administrator/manifests/libraries
+        // while its payload lives in libraries/[name]
+        $manifestPath = JPATH_ADMINISTRATOR . '/manifests/libraries';
+        $libraryPath = JPATH_SITE . '/libraries/testlibrary';
+        $sqlPath = $libraryPath . '/sql';
+
+        @mkdir($manifestPath, 0777, true);
+        @mkdir($sqlPath, 0777, true);
+
+        $manifest = <<<'XML_WRAP'
+        <?xml version="1.0" encoding="utf-8"?>
+        <extension type="library" method="upgrade">
+            <name>testlibrary</name>
+            <install>
+                <sql>
+                    <file driver="mysql" charset="utf8">sql/install.mysql.utf8.sql</file>
+                </sql>
+            </install>
+        </extension>
+        XML_WRAP;
+
+        $sqlContent = <<<'SQL_WRAP'
+        CREATE TABLE IF NOT EXISTS `#__testlibrary_consumers` (
+            id INT PRIMARY KEY,
+            element VARCHAR(255)
+        );
+        SQL_WRAP;
+
+        file_put_contents($manifestPath . '/testlibrary.xml', $manifest);
+        file_put_contents($sqlPath . '/install.mysql.utf8.sql', $sqlContent);
+
+        try {
+            $database = MockDatabaseFactory::createWithSequentialQueries([
+                [
+                    'method' => 'loadColumn',
+                    'return' => [
+                        'test_content',
+                        'test_extensions',
+                        'test_testlibrary_consumers', // Declared by the library manifest
+                    ],
+                ],
+                [
+                    'method' => 'loadObjectList',
+                    'return' => [],
+                ],
+            ]);
+            $this->orphanedTablesCheck->setDatabase($database);
+
+            $result = $this->orphanedTablesCheck->run();
+
+            // A library-owned table is not orphaned just because no component declares it
+            $this->assertSame(HealthStatus::Good, $result->healthStatus);
+        } finally {
+            @unlink($manifestPath . '/testlibrary.xml');
+            @unlink($sqlPath . '/install.mysql.utf8.sql');
+            @rmdir($sqlPath);
+            @rmdir($libraryPath);
+        }
+    }
+
+    public function testRunParsesLibraryTablesFromConventionalPathWithoutManifestSql(): void
+    {
+        // Mirrors the component fallback: a library that ships install SQL at a
+        // conventional path without declaring it in <install><sql>
+        $manifestPath = JPATH_ADMINISTRATOR . '/manifests/libraries';
+        $libraryPath = JPATH_SITE . '/libraries/fallbacklibrary';
+        $sqlPath = $libraryPath . '/sql';
+
+        @mkdir($manifestPath, 0777, true);
+        @mkdir($sqlPath, 0777, true);
+
+        $manifest = <<<'XML_WRAP'
+        <?xml version="1.0" encoding="utf-8"?>
+        <extension type="library" method="upgrade">
+            <name>fallbacklibrary</name>
+        </extension>
+        XML_WRAP;
+
+        $sqlContent = <<<'SQL_WRAP'
+        CREATE TABLE `#__fallbacklibrary_data` (
+            id INT PRIMARY KEY
+        );
+        SQL_WRAP;
+
+        file_put_contents($manifestPath . '/fallbacklibrary.xml', $manifest);
+        file_put_contents($sqlPath . '/install.mysql.utf8.sql', $sqlContent);
+
+        try {
+            $database = MockDatabaseFactory::createWithSequentialQueries([
+                [
+                    'method' => 'loadColumn',
+                    'return' => [
+                        'test_content',
+                        'test_fallbacklibrary_data',
+                    ],
+                ],
+                [
+                    'method' => 'loadObjectList',
+                    'return' => [],
+                ],
+            ]);
+            $this->orphanedTablesCheck->setDatabase($database);
+
+            $result = $this->orphanedTablesCheck->run();
+
+            $this->assertSame(HealthStatus::Good, $result->healthStatus);
+        } finally {
+            @unlink($manifestPath . '/fallbacklibrary.xml');
+            @unlink($sqlPath . '/install.mysql.utf8.sql');
+            @rmdir($sqlPath);
+            @rmdir($libraryPath);
+        }
+    }
+
     public function testRunParsesSqlWithDifferentTableFormats(): void
     {
         // Create a component with various CREATE TABLE formats


### PR DESCRIPTION
## The problem

`OrphanedTablesCheck` only ever looks at components. Its SQL-parsing strategy has a single scan root:

```php
$componentPath = JPATH_ADMINISTRATOR . '/components';
$components    = glob($componentPath . '/com_*', GLOB_ONLYDIR);
```

Libraries declare `<install><sql><file>` in their manifests exactly as components do, and they create tables — typically a registry shared by the extensions depending on them. Because nothing reads those manifests, **every library-owned table is reported as orphaned on every run**, and there is nothing the site owner can do to make the warning correct short of dropping a table the site needs.

Concrete case: on a Joomla 6.1.2 site, `#__bsms_scripture_consumers` is created by `lib_cwmscripture` (`sql/install.mysql.utf8.sql`, declared under `<install><sql>`), and is reported orphaned. It is the registry that prevents a package uninstall destroying scripture data shared by several extensions — the one table on that site you least want an admin to drop on the strength of this warning.

## The fix

`getSqlPathsFromManifestFile($xmlFile, $baseDir)` is extracted from `getSqlPathsFromManifest()` with identical parsing, but taking the manifest to read and the directory to resolve against as separate arguments — for a library those are different places (`administrator/manifests/libraries/<name>.xml` vs `libraries/<name>`), whereas for a component they're the same. It returns `?array` so the caller can distinguish "not a manifest declaring SQL, try the next file" from "handled, stop", preserving the original `continue`/`break` semantics including the empty-`<file>` edge case.

`getLibraryTablesFromSql()` then walks `administrator/manifests/libraries/*.xml` and mirrors the component fallback list for libraries shipping SQL at a conventional path without declaring it.

This can only ever *remove* false positives — it adds to the expected-table set and changes no reporting logic.

## Two related observations, deliberately not changed here

**1. `getExtensionTablesByPrefix()` has the same components-only assumption** (`if ($extension->type !== 'component') continue;`). I left it alone on purpose. It matches `<prefix> . <element>`, and non-component elements are short and generic — core Joomla alone ships plugins with elements `log`, `cache`, `debug`, `remember`. Admitting those would whitelist every table starting `<prefix>log_`, `<prefix>cache_`, and so on, trading today's false positives for **false negatives**, which is the worse direction for this check. Happy to revisit if you'd like it guarded differently.

**2. Component tables currently hang on a single mechanism.** With libraries unscanned, all 26 tables of the component in the case above are attributed solely by parsing its one `install.mysql.utf8.sql`. If that file moved or stopped being declared, all 26 would be reported orphaned in one audit. Not something this PR changes — noted because it's what makes the components-only assumption worth fixing at all.

## Testing

Two tests added, following the existing fixture idiom: one for the manifest-declared path, one for the conventional-path fallback.

- Full suite: **2690 tests, 5949 assertions, passing** (1 pre-existing skip)
- **PHPStan level 8: no errors**
- Both new tests were verified to **fail without the source change** (`Warning` instead of `Good`), so they aren't vacuous
- ⚠️ `composer ecs` fails on this machine with `Unknown named parameter $strict`, thrown from `ServiceContainerFactory` before any file is analysed. I confirmed by stashing my changes that it fails identically on a pristine checkout of `main`, so it's a local ECS/PHP-version issue rather than anything in this PR — flagging it rather than hiding it.
